### PR TITLE
Introduce a new feature for job output parameters

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationFactory.groovy
@@ -866,8 +866,10 @@ public class ConfigurationFactory {
 
         String pName = child.@scriptparameter.text();
         String fnpSelTag = extractAttributeText(child, "fnpatternselectiontag", FilenamePattern.DEFAULT_SELECTION_TAG);
-        boolean check = Boolean.parseBoolean(extractAttributeText(child, "check", "true"));
         String parentFileVariable = extractAttributeText(child, "variable", null); //This is only the case for child files.
+        ToolEntry.ToolFileParameterCondition check = new ToolEntry.ToolFileParameterCondition(extractAttributeText(child, "check", "true"));
+
+        if(check && check.startsWith("conditional:"))
 
         List<ToolEntry.ToolConstraint> constraints = new LinkedList<ToolEntry.ToolConstraint>();
         for (constraint in child.constraint) {

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationFactory.groovy
@@ -29,7 +29,6 @@ import org.apache.commons.io.filefilter.WildcardFileFilter
 
 import java.lang.reflect.*
 import java.util.logging.*
-import java.util.regex.Pattern
 
 import static de.dkfz.roddy.StringConstants.*
 
@@ -867,7 +866,7 @@ public class ConfigurationFactory {
         String pName = child.@scriptparameter.text();
         String fnpSelTag = extractAttributeText(child, "fnpatternselectiontag", FilenamePattern.DEFAULT_SELECTION_TAG);
         String parentFileVariable = extractAttributeText(child, "variable", null); //This is only the case for child files.
-        ToolEntry.ToolFileParameterCondition check = new ToolEntry.ToolFileParameterCondition(extractAttributeText(child, "check", "true"));
+        ToolEntry.ToolFileParameterCheckCondition check = new ToolEntry.ToolFileParameterCheckCondition(extractAttributeText(child, "check", "true"));
 
         if(check && check.startsWith("conditional:"))
 

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.java
@@ -141,6 +141,7 @@ public class ConfigurationValue implements RecursiveOverridableMapContainer.Iden
 
         String temp = f.getAbsolutePath();
         temp = temp.contains("${pid}") ? replaceString(temp, "${pid}", dataSet.getId()) : temp;
+        temp = temp.contains("${dataSet}") ? replaceString(temp, "${dataSet}", dataSet.getId()) : temp;
 
         return new File(temp);
     }

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolEntry.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolEntry.java
@@ -11,7 +11,9 @@ import de.dkfz.roddy.knowledge.files.BaseFile;
 import de.dkfz.roddy.knowledge.files.FileGroup;
 import de.dkfz.roddy.tools.BufferValue;
 import de.dkfz.roddy.tools.RoddyConversionHelperMethods;
+import de.dkfz.roddy.tools.RoddyIOHelperMethods;
 import de.dkfz.roddy.tools.TimeUnit;
+import examples.Exec;
 
 import java.lang.reflect.Method;
 import java.util.LinkedList;
@@ -213,6 +215,39 @@ public class ToolEntry implements RecursiveOverridableMapContainer.Identifiable 
         @Override
         public ToolStringParameter clone() {
             return new ToolStringParameter(scriptParameterName, cValueID, setby);
+        }
+    }
+
+    public static class ToolFileParameterCondition {
+
+        private String condition;
+
+        private Boolean pureBoolean;
+
+        public ToolFileParameterCondition(boolean pureBoolean) {
+            this.pureBoolean = Boolean.valueOf(pureBoolean);
+        }
+
+        public ToolFileParameterCondition(String condition) {
+            if(condition.startsWith("conditional:"))
+                this.condition = condition.substring(12);
+            else {
+                this.pureBoolean = RoddyConversionHelperMethods.toBoolean(condition, true);
+            }
+        }
+
+        public boolean isPureBoolean() {
+            return pureBoolean != null;
+        }
+
+        public String getCondition() {
+            return condition;
+        }
+
+        public boolean evaluate(ExecutionContext context) {
+            if (pureBoolean != null)
+                return pureBoolean;
+            return context.getConfiguration().getConfigurationValues().getBoolean(condition, true);
         }
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/config/ToolEntry.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ToolEntry.java
@@ -11,11 +11,8 @@ import de.dkfz.roddy.knowledge.files.BaseFile;
 import de.dkfz.roddy.knowledge.files.FileGroup;
 import de.dkfz.roddy.tools.BufferValue;
 import de.dkfz.roddy.tools.RoddyConversionHelperMethods;
-import de.dkfz.roddy.tools.RoddyIOHelperMethods;
 import de.dkfz.roddy.tools.TimeUnit;
-import examples.Exec;
 
-import java.io.File;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
@@ -219,26 +216,33 @@ public class ToolEntry implements RecursiveOverridableMapContainer.Identifiable 
         }
     }
 
-    public static class ToolFileParameterCondition {
+    /**
+     * The class defines a state for the check tag of tool output parameters
+     * check can hold:
+     *  true                   - The value will be checked on rerun
+     *  false                  - The value will NOT be checked
+     *  conditionial:somevalue - The check is true or false depending on the somevalue named variable
+     */
+    public static class ToolFileParameterCheckCondition {
 
         private String condition;
 
-        private Boolean pureBoolean;
+        private Boolean booleanValue;
 
-        public ToolFileParameterCondition(boolean pureBoolean) {
-            this.pureBoolean = Boolean.valueOf(pureBoolean);
+        public ToolFileParameterCheckCondition(boolean value) {
+            this.booleanValue = Boolean.valueOf(value);
         }
 
-        public ToolFileParameterCondition(String condition) {
+        public ToolFileParameterCheckCondition(String condition) {
             if(condition.startsWith("conditional:"))
                 this.condition = condition.substring(12);
             else {
-                this.pureBoolean = RoddyConversionHelperMethods.toBoolean(condition, true);
+                this.booleanValue = RoddyConversionHelperMethods.toBoolean(condition, true);
             }
         }
 
-        public boolean isPureBoolean() {
-            return pureBoolean != null;
+        public boolean isBoolean() {
+            return booleanValue != null;
         }
 
         public String getCondition() {
@@ -246,8 +250,8 @@ public class ToolEntry implements RecursiveOverridableMapContainer.Identifiable 
         }
 
         public boolean evaluate(ExecutionContext context) {
-            if (pureBoolean != null)
-                return pureBoolean;
+            if (booleanValue != null)
+                return booleanValue;
             return context.getConfiguration().getConfigurationValues().getBoolean(condition, true);
         }
     }
@@ -262,15 +266,15 @@ public class ToolEntry implements RecursiveOverridableMapContainer.Identifiable 
         public final List<ToolConstraint> constraints;
         public final String scriptParameterName;
         public final String filenamePatternSelectionTag;
-        public final ToolFileParameterCondition checkFile;
+        public final ToolFileParameterCheckCondition checkFile;
         public final String parentVariable;
         private List<ToolFileParameter> childFiles;
 
-        public ToolFileParameter(Class<BaseFile> fileClass, List<ToolConstraint> constraints, String scriptParameterName, ToolFileParameterCondition checkFile) {
+        public ToolFileParameter(Class<BaseFile> fileClass, List<ToolConstraint> constraints, String scriptParameterName, ToolFileParameterCheckCondition checkFile) {
             this(fileClass, constraints, scriptParameterName, checkFile, FilenamePattern.DEFAULT_SELECTION_TAG, null, null);
         }
 
-        public ToolFileParameter(Class<BaseFile> fileClass, List<ToolConstraint> constraints, String scriptParameterName, ToolFileParameterCondition checkFile, String filenamePatternSelectionTag, List<ToolFileParameter> childFiles, String parentVariable) {
+        public ToolFileParameter(Class<BaseFile> fileClass, List<ToolConstraint> constraints, String scriptParameterName, ToolFileParameterCheckCondition checkFile, String filenamePatternSelectionTag, List<ToolFileParameter> childFiles, String parentVariable) {
             super(scriptParameterName);
             this.fileClass = fileClass;
             this.constraints = constraints != null ? constraints : new LinkedList<>();

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/LocalExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/LocalExecutionService.groovy
@@ -72,7 +72,7 @@ public class LocalExecutionService extends ExecutionService {
     }
 
     @Override
-    protected String handleServiceBasedJobExitStatus(Command command, ExecutionResult res, FileOutputStream outputStream) {
+    protected String handleServiceBasedJobExitStatus(Command command, ExecutionResult res, OutputStream outputStream) {
         if (command.isBlockingCommand()) {
             command.setExecutionID(JobManager.getInstance().createJobDependencyID(command.getJob(), res.processID));
 

--- a/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/io/SSHExecutionService.groovy
@@ -47,6 +47,8 @@ class SSHExecutionService extends RemoteExecutionService {
     public static final LoggerWrapper logger = LoggerWrapper.getLogger(SSHExecutionService.class.name);
 
     public static class SSHPoolConnectionSet {
+        public Session session;
+
         public SSHClient client;
 
         public SFTPClient sftpClient;
@@ -134,9 +136,8 @@ class SSHExecutionService extends RemoteExecutionService {
                 c.startSession();
                 t2 = System.nanoTime();
                 logger.postSometimesInfo(RoddyIOHelperMethods.printTimingInfo("start ssh client session", t1, t2));
-
-
             } catch (Exception ex) {
+                println(ex);
             }
             client = c;
             sftpClient = client.newSFTPClient();
@@ -332,6 +333,15 @@ class SSHExecutionService extends RemoteExecutionService {
 //            }
     }
 
+    public String readStream(InputStream inputStream) {
+        ByteArrayOutputStream result = new ByteArrayOutputStream()
+        byte[] buffer = new byte[1024]
+        int length
+        while ((length = inputStream.read(buffer)) != -1)
+            result.write(buffer, 0 , length)
+        return result.toString("UTF-8")
+    }
+
 //    @Override
     public
     synchronized List<String> _execute(String command, boolean waitFor = true, boolean ignoreError = false, OutputStream outputStream = null) {
@@ -344,16 +354,20 @@ class SSHExecutionService extends RemoteExecutionService {
             set.acquire();
             Session session = sshClient.startSession();
             Session.Command cmd;
+            //long tBefore = System.nanoTime()
             try {
                 cmd = session.exec(command)
             } finally {
                 set.release();
             }
-            String content = IOUtils.readFully(cmd.getInputStream()).toString();
-            session.close();
+            //String content = IOUtils.readFully(cmd.getInputStream()).toString();
+            String content = readStream(cmd.getInputStream())
+            //measureStop(tBefore, "SSH: ${command}", LoggerWrapper.VERBOSITY_ALWAYS)
+            //session.close();
 
             cmd.join();
             session.close();
+
 
             // Get the exit status of the process. In case of things like caught signals (SEGV-Segmentation fault), the value is null and will be set to 256.
             Integer exitStatus = cmd.getExitStatus();

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
@@ -272,7 +272,7 @@ class GenericMethod {
         if (calledTool.getOutputParameters(configuration).size() == 1) {
             ToolEntry.ToolParameter tparm = calledTool.getOutputParameters(configuration)[0];
             if (tparm instanceof ToolEntry.ToolFileParameter) {
-                outputObject = createOutputFile(tparm) as F
+                outputObject = createOutputFile(tparm as ToolEntry.ToolFileParameter) as F
 
             } else if (tparm instanceof ToolEntry.ToolTupleParameter) {
                 outputObject = createOutputTuple(tparm as ToolEntry.ToolTupleParameter) as F
@@ -426,7 +426,7 @@ class GenericMethod {
             throw (ex);
         }
 
-        if (!fileParameter.checkFile)
+        if (!fileParameter.checkFile.evaluate(context))
             bf.setAsTemporaryFile();
 
         if (allInputFiles.size() > 1)

--- a/RoddyCore/src/de/dkfz/roddy/tools/RoddyIOHelperMethods.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/tools/RoddyIOHelperMethods.groovy
@@ -354,6 +354,55 @@ class RoddyIOHelperMethods {
                 o: (rights & 0007)]
     }
 
+    /** Split a pathname string into components (using '/'). Empty path components, as they occur between double
+     *  component separators ('//') are omitted.
+     *
+     * @param pathname
+     * @return
+     */
+    public static ArrayList<String> splitPathname(String pathname) {
+        pathname.split(StringConstants.SPLIT_SLASH).findAll({it != ""}) as ArrayList<String>
+    }
+
+    public static Optional<Integer> findComponentIndexInPath(String path, String component) {
+        Integer index = splitPathname(path).findIndexOf { it -> it == component }
+        if (-1 == index) {
+            Optional.empty()
+        } else {
+            Optional.of(index)
+        }
+    }
+
+    /** Match a variable, defined by a pattern in a path. This checks that all leading path components
+     *  that are not variable definitions in the pattern (i.e. ${someVar}) are identical for both the
+     *  pattern and the path. If there is a mismatch, a RuntimeException is raised. Only the first match
+     *  is considered. Later path components may diverge.
+     *
+     * @param pattern    Path pattern, e.g. /path/to/${variable}/to/be/matched
+     * @param variable   Variable to be matched, e.g. pid. ${variable} will be searched for in pattern.
+     * @param path       Path containing the value. The path value that is matched in here will be returned
+     * @return
+     */
+    public static Optional<String> getPatternVariableFromPath(String pattern, String variable, String path) {
+        ArrayList<String> patternComponents = splitPathname(pattern)
+        ArrayList<String> pathComponents = splitPathname(path)
+        Integer index = 0
+        while (index < Math.min(patternComponents.size(), pathComponents.size())) {
+            String patternC = patternComponents[index]
+            String pathC = pathComponents[index]
+            if (patternC.startsWith(StringConstants.DOLLAR_LEFTBRACE) && patternC.endsWith(StringConstants.BRACE_RIGHT)) {
+                if (patternC == "\${${variable}}") {
+                    return Optional.of(pathC)
+                }
+            } else if (patternC != pathC) {
+                throw new RuntimeException("Pattern and path have incompatible prefix path component ${index} before \${${variable}}. Pattern = ${pattern}, Path = ${path}")
+            }
+            ++index
+        }
+        return Optional.empty()
+    }
+
+
     public static String printTimingInfo(String info, long t1, long t2) {
         return "Timing " + info + ": " + ((t2 - t1) / 1000000) + " ms";
     }

--- a/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternTest.groovy
@@ -63,7 +63,7 @@ public class FilenamePatternTest {
         testClass = LibrariesFactory.getInstance().loadRealOrSyntheticClass("FilenamePatternTest_testFilenamePatternWithSelectionByToolID", BaseFile.class as Class<FileObject>);
 
         ToolEntry toolEntry = new ToolEntry("RoddyTests", "RoddyTests", "RoddyTestScript_ExecutionServiceTest.sh");
-        toolEntry.getOutputParameters(mockupConfig).add(new ToolEntry.ToolFileParameter(testClass, null, "TEST", true))
+        toolEntry.getOutputParameters(mockupConfig).add(new ToolEntry.ToolFileParameter(testClass, null, "TEST", new ToolEntry.ToolFileParameterCondition(true)))
 
         mockupConfig.getTools().add(toolEntry);
     }

--- a/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternTest.groovy
@@ -6,12 +6,8 @@
 
 package de.dkfz.roddy.config
 
-import de.dkfz.roddy.core.Analysis;
-import de.dkfz.roddy.core.DataSet;
-import de.dkfz.roddy.core.ExecutionContext;
-import de.dkfz.roddy.core.ExecutionContextLevel
+import de.dkfz.roddy.core.ExecutionContext
 import de.dkfz.roddy.core.MockupExecutionContextBuilder
-import de.dkfz.roddy.core.RuntimeService
 import de.dkfz.roddy.execution.jobs.Command
 import de.dkfz.roddy.execution.jobs.Job
 import de.dkfz.roddy.execution.jobs.JobDependencyID
@@ -63,7 +59,7 @@ public class FilenamePatternTest {
         testClass = LibrariesFactory.getInstance().loadRealOrSyntheticClass("FilenamePatternTest_testFilenamePatternWithSelectionByToolID", BaseFile.class as Class<FileObject>);
 
         ToolEntry toolEntry = new ToolEntry("RoddyTests", "RoddyTests", "RoddyTestScript_ExecutionServiceTest.sh");
-        toolEntry.getOutputParameters(mockupConfig).add(new ToolEntry.ToolFileParameter(testClass, null, "TEST", new ToolEntry.ToolFileParameterCondition(true)))
+        toolEntry.getOutputParameters(mockupConfig).add(new ToolEntry.ToolFileParameter(testClass, null, "TEST", new ToolEntry.ToolFileParameterCheckCondition(true)))
 
         mockupConfig.getTools().add(toolEntry);
     }

--- a/RoddyCore/test/de/dkfz/roddy/config/ToolEntryTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/ToolEntryTest.groovy
@@ -56,4 +56,22 @@ class ToolEntryTest extends GroovyTestCase {
                 assert entry.getResourceSet(createTestConfiguration(given)).getSize() == expected
         }
     }
+
+
+    /////// Tests for ToolFileParameterCondition
+    void testNewToolFileParameterCondition() {
+        def abc = new ToolEntry.ToolFileParameterCondition("conditional:abc")
+        assert ! abc.isPureBoolean()
+        assert abc.getCondition()
+
+        def pure = new ToolEntry.ToolFileParameterCondition("true")
+        assert pure.isPureBoolean()
+        assert pure.evaluate(null)
+        assert pure.getCondition() == null
+
+        pure = new ToolEntry.ToolFileParameterCondition("false")
+        assert pure.isPureBoolean()
+        assert pure.evaluate(null)
+        assert pure.getCondition() == null
+    }
 }

--- a/RoddyCore/test/de/dkfz/roddy/config/ToolEntryTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/ToolEntryTest.groovy
@@ -58,19 +58,19 @@ class ToolEntryTest extends GroovyTestCase {
     }
 
 
-    /////// Tests for ToolFileParameterCondition
+    /////// Tests for ToolFileParameterCheckCondition
     void testNewToolFileParameterCondition() {
-        def abc = new ToolEntry.ToolFileParameterCondition("conditional:abc")
-        assert ! abc.isPureBoolean()
+        def abc = new ToolEntry.ToolFileParameterCheckCondition("conditional:abc")
+        assert ! abc.isBoolean()
         assert abc.getCondition()
 
-        def pure = new ToolEntry.ToolFileParameterCondition("true")
-        assert pure.isPureBoolean()
+        def pure = new ToolEntry.ToolFileParameterCheckCondition("true")
+        assert pure.isBoolean()
         assert pure.evaluate(null)
         assert pure.getCondition() == null
 
-        pure = new ToolEntry.ToolFileParameterCondition("false")
-        assert pure.isPureBoolean()
+        pure = new ToolEntry.ToolFileParameterCheckCondition("false")
+        assert pure.isBoolean()
         assert pure.evaluate(null)
         assert pure.getCondition() == null
     }

--- a/RoddyCore/test/de/dkfz/roddy/tools/RoddyIOHelperMethodsTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/tools/RoddyIOHelperMethodsTest.groovy
@@ -7,17 +7,12 @@
 package de.dkfz.roddy.tools
 
 import de.dkfz.roddy.Constants
-import de.dkfz.roddy.RunMode
 import de.dkfz.roddy.core.MockupExecutionContextBuilder
-import de.dkfz.roddy.execution.io.ExecutionService
-import de.dkfz.roddy.execution.io.LocalExecutionService
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
-import groovy.transform.CompileStatic;
-import org.junit.Test;
-
-import java.util.Map;
-
-import static org.junit.Assert.*;
+import groovy.transform.CompileStatic
+import org.junit.Rule;
+import org.junit.Test
+import org.junit.rules.ExpectedException
 
 /**
  * Test class to cover RoddyIOHelperMethods.
@@ -26,6 +21,9 @@ import static org.junit.Assert.*;
  */
 @CompileStatic
 public class RoddyIOHelperMethodsTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none()
 
     @Test
     public void testGetMD5OfText() {
@@ -178,5 +176,31 @@ public class RoddyIOHelperMethodsTest {
             String rights, String res ->
                 assert res == RoddyIOHelperMethods.convertUMaskToAccessRights(rights);
         }
+    }
+
+    @Test
+    public void testSplitPathname() throws Exception {
+        assert RoddyIOHelperMethods.splitPathname("") == new ArrayList()
+        assert RoddyIOHelperMethods.splitPathname("/") == new ArrayList()
+        assert RoddyIOHelperMethods.splitPathname("/a/b") == ["a", "b"]
+        assert RoddyIOHelperMethods.splitPathname("//a/b/") == ["a", "b"]
+    }
+
+    @Test
+    public void testfindComponentIndexInPath() throws Exception {
+        assert RoddyIOHelperMethods.findComponentIndexInPath('/a/b/c', "c").get() == 2
+        assert RoddyIOHelperMethods.findComponentIndexInPath('////a/b//c///', "c").get() == 2
+        assert !RoddyIOHelperMethods.findComponentIndexInPath('/a/b/X', "c").isPresent()
+    }
+
+    @Test
+    public void testGetPatternVariableFromPath() throws Exception {
+        assert RoddyIOHelperMethods.getPatternVariableFromPath('/a/b/c/${var}/d', "var", '/a/b/c/theValue/x').get() == "theValue"
+        assert !RoddyIOHelperMethods.getPatternVariableFromPath('/a/b/c', "var", "/a/b/c/d").isPresent()
+        assert !RoddyIOHelperMethods.getPatternVariableFromPath('/a/b/c/${var}/d', "var", "/a/b/").isPresent()
+        assert RoddyIOHelperMethods.getPatternVariableFromPath('//a/b///c///${var}//d', "var", '/a////////b//c///theValue/x').get() == "theValue"
+
+        thrown.expect(RuntimeException.class)
+        RoddyIOHelperMethods.getPatternVariableFromPath('/a/b/c/${var}', "var", '/A/b/c/theValue')
     }
 }

--- a/dist/bin/current/helperScripts/compileRoddyPlugin.sh
+++ b/dist/bin/current/helperScripts/compileRoddyPlugin.sh
@@ -16,7 +16,7 @@ requestedAPIVersion=`grep RoddyAPIVersion buildinfo.txt | cut -d "=" -f 2`
 #cat buildinfo.txt
 
 echo "Increasing build number and date"
-pluginClass=`find $srcDirectory -name "*Plugin.java" | head -n 1`
+pluginClass=`find $srcDirectory/ -name "*Plugin.java" | head -n 1`
 groovy ${SCRIPTS_DIR}/IncreaseAndSetBuildVersion.groovy $srcDirectory/buildversion.txt $pluginClass
 echo "  Increased to" `head -n 1 $srcDirectory/buildversion.txt`.`tail -n 1 $srcDirectory/buildversion.txt`
 


### PR DESCRIPTION
This commit changes the behaviour of the boolean "check" for job output file
checks. Instead of a simple boolean, we now will have a more
sophisticated conditional class. This can either be a pure boolean OR a
conditional.

Syntax is check="conditional:VARNAME"
or
check="true|false"

Errors in the definition will all fall back to true!