### PR TITLE
Fix behaviour of ${jobParameter option in filename patterns

### DIFF
--- a/RoddyCore/RoddyCore.iml
+++ b/RoddyCore/RoddyCore.iml
@@ -13,20 +13,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
     <content url="file://$MODULE_DIR$/../dist/bin">
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/current/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.1.5/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.2.49/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.2.112/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.1.24/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.1.26/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.1.14/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.1.28/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.1.7/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.0.469/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.2.66/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.2.87/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/2.2.10/helperScripts" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../dist/bin/current/xmlvalidation" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.0.469" />
       <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.1.14" />
       <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.1.24" />
@@ -37,10 +23,12 @@
       <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.2.10" />
       <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.2.112" />
       <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.2.112-1" />
+      <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.2.119" />
       <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.2.49" />
       <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.2.66" />
       <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.2.87" />
       <excludeFolder url="file://$MODULE_DIR$/../dist/bin/2.3.115" />
+      <excludeFolder url="file://$MODULE_DIR$/../dist/bin/libs_2.2.x" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
@@ -11,12 +11,15 @@ import de.dkfz.roddy.core.ExecutionContext;
 import de.dkfz.roddy.knowledge.files.BaseFile;
 import de.dkfz.roddy.knowledge.files.FileStageSettings;
 
+
 import java.io.File;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
 import static de.dkfz.roddy.StringConstants.*;
+import de.dkfz.roddy.config.FilenamePatternHelper.Command;
+import de.dkfz.roddy.config.FilenamePatternHelper.CommandAttribute;
 
 /**
  * Filename patterns are stored in a configuration file. They are project specific and should be fully configurable.
@@ -96,7 +99,7 @@ public abstract class FilenamePattern implements RecursiveOverridableMapContaine
         }
 
         while (temp.contains(PLACEHOLDER_CVALUE)) {
-            Command command = extractCommand(PLACEHOLDER_CVALUE, temp);
+            Command command = FilenamePatternHelper.extractCommand(PLACEHOLDER_CVALUE, temp);
             CommandAttribute name = command.attributes.get("name");
             CommandAttribute def = command.attributes.get("default");
             if (name != null) {
@@ -175,7 +178,7 @@ public abstract class FilenamePattern implements RecursiveOverridableMapContaine
                 temp = temp.replace("${sourcefile}", sourcepath.getAbsolutePath());
                 temp = temp.replace("${sourcefileAtomic}", sourcepath.getName());
                 if (temp.contains(PLACEHOLDER_SOURCEFILE_PROPERTY)) { //Replace the string with a property value
-                    Command command = extractCommand(PLACEHOLDER_SOURCEFILE_PROPERTY, temp);
+                    Command command = FilenamePatternHelper.extractCommand(PLACEHOLDER_SOURCEFILE_PROPERTY, temp);
                     String pName = command.attributes.keySet().toArray()[0].toString();
 
                     String accessorName = "get" + pName.substring(0, 1).toUpperCase() + pName.substring(1);
@@ -184,7 +187,7 @@ public abstract class FilenamePattern implements RecursiveOverridableMapContaine
                     temp = temp.replace(command.name, value);
                 }
                 if (temp.contains(PLACEHOLDER_SOURCEFILE_ATOMIC_PREFIX)) {
-                    Command command = extractCommand(PLACEHOLDER_SOURCEFILE_ATOMIC_PREFIX, temp);
+                    Command command = FilenamePatternHelper.extractCommand(PLACEHOLDER_SOURCEFILE_ATOMIC_PREFIX, temp);
                     CommandAttribute att = command.attributes.get("delimiter");
                     if (att != null) {
                         String sourcename = sourcepath.getName();
@@ -209,45 +212,4 @@ public abstract class FilenamePattern implements RecursiveOverridableMapContaine
         return temp;
     }
 
-    public static class Command {
-        public final String name;
-        public final Map<String, CommandAttribute> attributes = new HashMap<String, CommandAttribute>();
-
-        private Command(String name, Map<String, CommandAttribute> attributes) {
-            this.name = name;
-            if (attributes != null)
-                this.attributes.putAll(attributes);
-        }
-    }
-
-    public static class CommandAttribute {
-        public final String name;
-        public final String value;
-
-        private CommandAttribute(String name, String value) {
-            this.name = name;
-            this.value = value;
-        }
-    }
-
-    public static Command extractCommand(String commandID, String temp) {
-        int startIndex = temp.indexOf(commandID);
-        int endIndex = temp.indexOf(BRACE_RIGHT, startIndex);
-        String command = temp.substring(startIndex, endIndex + 1);
-
-        Map<String, CommandAttribute> attributes = new HashMap<String, CommandAttribute>();
-
-        String[] split = command.split(SPLIT_COMMA);
-        for (int i = 1; i < split.length; i++) { //Start with the first option.
-            String _split = split[i].replaceAll("[^0-9a-zA-Z=.-_+#]", EMPTY);
-            String[] attributeSplit = _split.split(SPLIT_EQUALS);
-            String name = attributeSplit[0];
-            String value = EMPTY;
-            if (attributeSplit.length == 2)
-                value = attributeSplit[1];
-            attributes.put(name, new CommandAttribute(name, value));
-        }
-
-        return new Command(command, attributes);
-    }
 }

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
@@ -6,6 +6,7 @@
 
 package de.dkfz.roddy.config
 
+import de.dkfz.roddy.core.ExecutionContext
 import de.dkfz.roddy.core.ExecutionContextError
 import de.dkfz.roddy.knowledge.files.BaseFile
 import groovy.transform.CompileStatic
@@ -43,7 +44,7 @@ class FilenamePatternHelper {
         }
     }
 
-    public static Command extractCommand(BaseFile baseFile, String commandID, String temp, int startIndex = -1) {
+    public static Command extractCommand(ExecutionContext context, String commandID, String temp, int startIndex = -1) {
         if (startIndex == -1)
             startIndex = temp.indexOf(commandID);
         int endIndex = temp.indexOf(BRACE_RIGHT, startIndex);
@@ -69,7 +70,7 @@ class FilenamePatternHelper {
 
         // Check if the attribute at least has a name tag
         if(!attributes["name"]) {
-            baseFile.getExecutionContext().addErrorEntry(ExecutionContextError.EXECUTION_SETUP_INVALID.expand("The jobParameter for ${command} must have a name tag with a value."))
+            context.addErrorEntry(ExecutionContextError.EXECUTION_SETUP_INVALID.expand("The jobParameter for ${command} must have a name tag with a value."))
         }
 
         return new Command(command, attributes);
@@ -84,7 +85,7 @@ class FilenamePatternHelper {
      * @param temp
      * @return
      */
-    public static List<Command> extractCommands(String commandID, String temp) {
+    public static List<Command> extractCommands(ExecutionContext context, String commandID, String temp) {
         def cmds = []
         // This simple method to get the no of instances is not possible! Groovy will try to compile a pattern from things like ${jobParameter
         // It seems, that $ and { trigger an internal mechanism when used with findAll.
@@ -100,7 +101,7 @@ class FilenamePatternHelper {
         int lastIndex = 0
         for (int i = 0; i < no; i++) {
             lastIndex = temp.indexOf(commandID, lastIndex + 1);
-            cmds << extractCommand(commandID, temp, lastIndex);
+            cmds << extractCommand(context, commandID, temp, lastIndex);
         }
         return cmds
     }

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2017 eilslabs.
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
+
+package de.dkfz.roddy.config
+
+import groovy.transform.CompileStatic
+
+import static de.dkfz.roddy.StringConstants.BRACE_RIGHT
+import static de.dkfz.roddy.StringConstants.EMPTY
+import static de.dkfz.roddy.StringConstants.EMPTY
+import static de.dkfz.roddy.StringConstants.SPLIT_COMMA
+import static de.dkfz.roddy.StringConstants.SPLIT_EQUALS
+
+/**
+ * Created by heinold on 10.01.17.
+ */
+@CompileStatic
+class FilenamePatternHelper {
+
+    public static class Command {
+        public final String name;
+        public final Map<String, CommandAttribute> attributes = new HashMap<String, CommandAttribute>();
+
+        public Command(String name, Map<String, CommandAttribute> attributes) {
+            this.name = name;
+            if (attributes != null)
+                this.attributes.putAll(attributes);
+        }
+    }
+
+    public static class CommandAttribute {
+        public final String name;
+        public final String value;
+
+        public CommandAttribute(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+    }
+
+    public static Command extractCommand(String commandID, String temp, int startIndex = -1) {
+        if (startIndex == -1)
+            startIndex = temp.indexOf(commandID);
+        int endIndex = temp.indexOf(BRACE_RIGHT, startIndex);
+        String command = temp[startIndex .. endIndex]
+
+        Map<String, CommandAttribute> attributes = [:]
+
+        String[] split = command.split(SPLIT_COMMA);
+        for (int i = 1; i < split.length; i++) { //Start with the first option.
+            String _split = split[i].replaceAll("[^0-9a-zA-Z=.-_+#]", EMPTY);
+            String[] attributeSplit = _split.split(SPLIT_EQUALS);
+            String name = attributeSplit[0];
+            String value = EMPTY;
+            if (attributeSplit.length == 2)
+                value = attributeSplit[1].replace('"', EMPTY);
+            attributes[name] = new CommandAttribute(name, value);
+        }
+
+        return new Command(command, attributes);
+    }
+
+    /**
+     * Extract a list of similar commands from a string.
+     * The code looks overly complicated due to missing functions in groovy or due to
+     * funny behaviour of groovy methods. Maybe it would've been better to implement it in Java
+     * I don't know.
+     * @param commandID
+     * @param temp
+     * @return
+     */
+    public static List<Command> extractCommands(String commandID, String temp) {
+        def cmds = []
+        // This simple method to get the no of instances is not possible! Groovy will try to compile a pattern from things like ${jobParameter
+        // It seems, that $ and { trigger an internal mechanism when used with findAll.
+        //        int no = temp.findAll(commandID).size()
+
+        // Now go for a more complicated BUT secure way; (Still I hate it)
+        String _temp = temp.replace("\${", "##;##")
+        String _commandID = commandID.replace("\${", "##;##")
+        int no = _temp.findAll(_commandID).size()
+
+        // Groovy does not have a simple findAllIndexValuesOf or something like it.
+        // Maybe with a pattern matching. But I don't want to waste too much time on it.
+        int lastIndex = 0
+        for (int i = 0; i < no; i++) {
+            lastIndex = temp.indexOf(commandID, lastIndex + 1);
+            cmds << extractCommand(commandID, temp, lastIndex);
+        }
+        return cmds
+    }
+}

--- a/RoddyCore/src/de/dkfz/roddy/config/TestFileStageSettings.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/TestFileStageSettings.java
@@ -14,7 +14,7 @@ import de.dkfz.roddy.knowledge.files.FileStageSettings;
  * Created by michael on 28.10.14.
  */
 public class TestFileStageSettings extends FileStageSettings {
-    protected TestFileStageSettings() {
+    public TestFileStageSettings() {
         super(null, null);
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
@@ -252,7 +252,7 @@ public class Job {
         }
 
         String absolutePath = path.getAbsolutePath()
-        List<FilenamePatternHelper.Command> commands = FilenamePatternHelper.extractCommands(PLACEHOLDER_JOBPARAMETER, absolutePath);
+        List<FilenamePatternHelper.Command> commands = FilenamePatternHelper.extractCommands(bf, PLACEHOLDER_JOBPARAMETER, absolutePath);
         for (FilenamePatternHelper.Command command : commands) {
             FilenamePatternHelper.CommandAttribute name = command.attributes.get("name");
             if (name != null) {

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
@@ -9,7 +9,8 @@ package de.dkfz.roddy.execution.jobs
 import de.dkfz.roddy.AvailableFeatureToggles;
 import de.dkfz.roddy.Constants
 import de.dkfz.roddy.Roddy
-import de.dkfz.roddy.config.FilenamePattern;
+import de.dkfz.roddy.config.FilenamePattern
+import de.dkfz.roddy.config.FilenamePatternHelper;
 import de.dkfz.roddy.execution.io.ExecutionService
 import de.dkfz.roddy.tools.LoggerWrapper;
 import de.dkfz.roddy.tools.RoddyIOHelperMethods;
@@ -147,7 +148,7 @@ public class Job {
         this.parentFiles = parentFiles ?: new LinkedList<BaseFile>();
         if (parentFiles != null) {
             for (BaseFile bf : parentFiles) {
-                if(bf.isSourceFile() && bf.getCreatingJobsResult() == null) continue;
+                if (bf.isSourceFile() && bf.getCreatingJobsResult() == null) continue;
                 try {
                     JobDependencyID jobid = bf.getCreatingJobsResult()?.getJobID();
                     if (jobid?.isValidID()) {
@@ -219,7 +220,7 @@ public class Job {
             //TODO This is not the best way to do this, think of a better one which is more generic.
 
             List<Object> convertedParameters = new LinkedList<>();
-            for (Object o : ((Collection) _v)) {
+            for (Object o : _v as Collection) {
                 if (o instanceof BaseFile) {
                     if (((BaseFile) o).getPath() != null)
                         convertedParameters.add(((BaseFile) o).getAbsolutePath());
@@ -241,21 +242,19 @@ public class Job {
     }
 
 
-    private File replaceParametersInFilePath(BaseFile bf, Map<String, Object> parameters) {
+    public static File replaceParametersInFilePath(BaseFile bf, Map<String, Object> parameters) {
         //TODO: It can occur that the regeneration of the filename is not valid!
 
         // Replace $_JOBPARAMETER items in path with proper values.
-        //TODO: Think how to best place this with parameters into the FilenamePattern class.
         File path = bf.getPath()
         if (path == null) {
             return null;
         }
 
         String absolutePath = path.getAbsolutePath()
-        if (absolutePath.contains(PLACEHOLDER_JOBPARAMETER)) {
-            FilenamePattern.Command command = FilenamePattern.extractCommand(PLACEHOLDER_JOBPARAMETER, absolutePath);
-            FilenamePattern.CommandAttribute name = command.attributes.get("name");
-//                    FilenamePattern.CommandAttribute defValue = command.attributes.get("default");
+        List<FilenamePatternHelper.Command> commands = FilenamePatternHelper.extractCommands(PLACEHOLDER_JOBPARAMETER, absolutePath);
+        for (FilenamePatternHelper.Command command : commands) {
+            FilenamePatternHelper.CommandAttribute name = command.attributes.get("name");
             if (name != null) {
                 String val = parameters[name.value];
                 if (val == null) {
@@ -463,13 +462,13 @@ public class Job {
 
         //More detailed if then because of enhanced debug / breakpoint possibilities
         if (isVerbosityHigh) {
-            if(parentJobIsDirty)
+            if (parentJobIsDirty)
                 dbgMessage << "\t* Job is set to rerun because a parent job is marked dirty" << sep;
             if (knownFilesCountMismatch)
                 dbgMessage << "\t* The number of existing files does not match with the number of files which should be created" << sep
-            if(fileUnverified)
+            if (fileUnverified)
                 dbgMessage << "\t* One or more files could not be verified" << sep;
-            if(parentFileIsDirty)
+            if (parentFileIsDirty)
                 dbgMessage << "\t* One or more of the jobs parent files could not be verified" << sep;
         }
         isDirty = true;

--- a/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternHelperTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternHelperTest.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017 eilslabs.
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
+
+package de.dkfz.roddy.config;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by heinold on 10.01.17.
+ */
+public class FilenamePatternHelperTest {
+
+    @Test
+    public void extractCommands() throws Exception {
+        String commandID = '\${jobParameter';
+        String temp = '/a/real/string/${jobParameter,name="test",default="abc"}/${jobParameter,name="test2"}/a_filename.txt'
+        def result = FilenamePatternHelper.extractCommands(commandID, temp)
+        assert result
+        assert result.size() == 2
+        assert result[0].attributes["name"].value == "test"
+        assert result[0].attributes["default"].value == "abc"
+        assert result[1].attributes["name"].value == "test2"
+    }
+
+    @Test
+    public void testExtractCommandsWithUnclosedLiterals() {
+        String commandID = '\${jobParameter';
+        String temp = '/a/real/string/${jobParameter,name="test"}/${jobParameter,name="test2"/a_filename.txt'
+        assert false
+    }
+
+}

--- a/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternTest.groovy
@@ -207,4 +207,14 @@ public class FilenamePatternTest {
         assert result != null
         assert result.class == testClass;
     }
+
+    @Test
+    public testExtractCommand() {
+
+    }
+
+    @Test
+    public testExtractCommands() {
+
+    }
 }

--- a/RoddyCore/test/de/dkfz/roddy/execution/jobs/JobTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/execution/jobs/JobTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017 eilslabs.
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
+
+package de.dkfz.roddy.execution.jobs
+
+import de.dkfz.roddy.config.TestFileStageSettings
+import de.dkfz.roddy.core.ExecutionContext
+import de.dkfz.roddy.core.MockupExecutionContextBuilder;
+import de.dkfz.roddy.knowledge.files.BaseFile
+import de.dkfz.roddy.knowledge.files.FileStageSettings
+import groovy.transform.CompileStatic;
+import org.junit.Test;
+import org.reflections.vfs.Vfs;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+import de.dkfz.roddy.knowledge.files.BaseFile.ConstructionHelperForBaseFiles
+import de.dkfz.roddy.knowledge.files.BaseFile.ConstructionHelperForManualCreation
+
+/**
+ * Created by heinold on 10.01.17.
+ */
+@CompileStatic
+public class JobTest {
+    @CompileStatic
+    public static class TestFile extends BaseFile {
+
+        public TestFile(de.dkfz.roddy.knowledge.files.BaseFile.ConstructionHelperForSourceFiles helper) {
+            super(helper);
+        }
+
+        public File getPath() {
+            return new File('/a/test/${jobParameter,name=\"abc\"}/${jobParameter,name=\"def\"}/text.txt');
+        }
+
+    }
+
+    @Test
+    public void replaceParametersInFilePath() throws Exception {
+        BaseFile bf = new TestFile(new BaseFile.ConstructionHelperForSourceFiles(new File("/invalid"), MockupExecutionContextBuilder.createSimpleContext(JobTest.name), new TestFileStageSettings<>(), null))
+        def parm = ["abc": "avalue",
+                    "def": "anothervalue"
+        ] as Map<String, Object>
+        assert Job.replaceParametersInFilePath(bf, parm) == new File('/a/test/avalue/anothervalue/text.txt')
+    }
+
+}


### PR DESCRIPTION
Formerly only the first option was clearly replaced, this is fixed.
Further bugfixes and code tests.
