### PR TITLE
Add initial checks, Fix cvalue dependency bug, Add --rv parameter

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -12,6 +12,7 @@ import de.dkfz.roddy.client.RoddyStartupOptions;
 import de.dkfz.roddy.client.cliclient.CommandLineCall;
 import de.dkfz.roddy.client.cliclient.RoddyCLIClient;
 import de.dkfz.roddy.client.rmiclient.RoddyRMIServer;
+import de.dkfz.roddy.execution.io.ExecutionHelper;
 import de.dkfz.roddy.tools.RoddyConversionHelperMethods;
 import de.dkfz.roddy.tools.RoddyIOHelperMethods;
 import de.dkfz.roddy.tools.AppConfig;
@@ -227,6 +228,10 @@ public class Roddy {
         time(null);
         LoggerWrapper.setup();
         logger.postAlwaysInfo("Roddy version " + Constants.APP_CURRENT_VERSION_STRING);
+
+        if(!performInitialCheck())
+            exit(1);
+
         time("ftoggleini");
         List<String> list = Arrays.asList(args);
         time("clc .1");
@@ -256,6 +261,22 @@ public class Roddy {
         time("exit");
     }
 
+    public static boolean performInitialCheck() {
+        List<String> errors = new LinkedList<>();
+        errors.add("Roddy cannot run:");
+        if(!ExecutionHelper.executeCommandWithExtendedResult("which jart").isSuccessful())
+            errors.add("\tTool jar not found.");
+        if(!ExecutionHelper.executeCommandWithExtendedResult("which zip").isSuccessful())
+            errors.add("\tTool zip not found.");
+        if(!ExecutionHelper.executeCommandWithExtendedResult("which unzip").isSuccessful())
+            errors.add("\tTool unzip not found.");
+
+        if(errors.size() == 1) return true;
+
+        logger.severe(RoddyIOHelperMethods.joinArray(errors.toArray(new String[0]), "\n"));
+        return false;
+    }
+
     public static void performInitialSetup(String[] args, RoddyStartupModes option) {
 
         runMode = CLI;
@@ -275,7 +296,7 @@ public class Roddy {
         displayShortWorkflowList = clc.isOptionSet(RoddyStartupOptions.shortlist);
         if (clc.isOptionSet(RoddyStartupOptions.useconfig))
             customPropertiesFile = clc.getOptionValue(RoddyStartupOptions.useconfig);
-        else if(clc.isOptionSet(RoddyStartupOptions.c))
+        else if (clc.isOptionSet(RoddyStartupOptions.c))
             customPropertiesFile = clc.getOptionValue(RoddyStartupOptions.c);
 
         for (RoddyStartupOptions startupOption : clc.getOptionList()) {
@@ -352,7 +373,6 @@ public class Roddy {
                 }
             }
         }
-//        return newArguments.toArray(new String[0]);
     }
 
     private static void initializeFeatureToggles() {
@@ -693,11 +713,17 @@ public class Roddy {
     }
 
     public static String getUsedRoddyVersion() {
-        String[] strClassPath = System.getProperty("java.class.path").split("[;:]");
-        if (getCommandLineCall().isOptionSet(RoddyStartupOptions.useRoddyVersion))
-            return getCommandLineCall().getOptionValue(RoddyStartupOptions.useRoddyVersion);
-        else
-            return getApplicationProperty("useRoddyVersion", LibrariesFactory.PLUGIN_VERSION_CURRENT);
+        String result = "";
+        CommandLineCall clc = getCommandLineCall();
+        for (RoddyStartupOptions opt : Arrays.asList(
+                RoddyStartupOptions.useRoddyVersion,
+                RoddyStartupOptions.useroddyversion,
+                RoddyStartupOptions.rv)) {
+            if (clc.isOptionSet(opt))
+                result = clc.getOptionValue(opt);
+        }
+        if (!RoddyConversionHelperMethods.isNullOrEmpty(result)) return result;
+        return getApplicationProperty("useRoddyVersion", LibrariesFactory.PLUGIN_VERSION_CURRENT);
     }
 
     public static File getRoddyBinaryFolder() {

--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -264,7 +264,7 @@ public class Roddy {
     public static boolean performInitialCheck() {
         List<String> errors = new LinkedList<>();
         errors.add("Roddy cannot run:");
-        if(!ExecutionHelper.executeCommandWithExtendedResult("which jart").isSuccessful())
+        if(!ExecutionHelper.executeCommandWithExtendedResult("which jar").isSuccessful())
             errors.add("\tTool jar not found.");
         if(!ExecutionHelper.executeCommandWithExtendedResult("which zip").isSuccessful())
             errors.add("\tTool zip not found.");

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModes.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModes.groovy
@@ -4,17 +4,17 @@
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */
 
-package de.dkfz.roddy.client;
+package de.dkfz.roddy.client
 
-import de.dkfz.roddy.Constants;
-import static de.dkfz.roddy.client.RoddyStartupOptions.*;
-import static de.dkfz.roddy.client.RoddyStartupModeScopes.*;
+import de.dkfz.roddy.Constants
+import static de.dkfz.roddy.client.RoddyStartupOptions.*
+import static de.dkfz.roddy.client.RoddyStartupModeScopes.*
 
 /**
  * Contains the possible startup modes for Roddy.
  */
 @groovy.transform.CompileStatic
-public enum RoddyStartupModes {
+enum RoddyStartupModes {
 
     importworkflow(SCOPE_REDUCED),
 
@@ -82,9 +82,9 @@ public enum RoddyStartupModes {
 
     createworkflow(SCOPE_REDUCED, [useconfig]),
 
-    setup(SCOPE_CLI);
+    setup(SCOPE_CLI)
 
-    public final int scope;
+    public final int scope
 
     /**
      * A list of valid startup options for this startup mode.
@@ -93,90 +93,106 @@ public enum RoddyStartupModes {
 
     RoddyStartupModes(int scope, List<RoddyStartupOptions> validOptions = []) {
         this.validOptions = validOptions
-        this.scope = scope;
+        this.scope = scope
     }
 
     private static void printCommand(RoddyStartupModes option, String parameters) {
-        System.out.println(String.format("  %s %s " + Constants.ENV_LINESEPARATOR, option.toString(), parameters));
+        System.out.println(String.format("  %s %s " + Constants.ENV_LINESEPARATOR, option.toString(), parameters))
     }
 
     private static void printCommand(RoddyStartupModes option, String parameters, String... description) {
-        StringBuilder formattedDescription = new StringBuilder();
+        StringBuilder formattedDescription = new StringBuilder()
         if (description.length > 0) {
-            formattedDescription.append(description[0]);
+            formattedDescription.append(description[0])
             for (int i = 1; i < description.length; i++) {
-                formattedDescription.append(Constants.ENV_LINESEPARATOR).append("\t").append(description[i]);
+                formattedDescription.append(Constants.ENV_LINESEPARATOR).append("\t").append(description[i])
             }
         }
-        System.out.println(String.format("  %s %s " + Constants.ENV_LINESEPARATOR + "\t%s" + Constants.ENV_LINESEPARATOR, option.toString(), parameters, formattedDescription.toString()));
+        System.out.println(String.format("  %s %s " + Constants.ENV_LINESEPARATOR + "\t%s" + Constants.ENV_LINESEPARATOR, option.toString(), parameters, formattedDescription.toString()))
     }
 
-    public static void printCommandLineOptions() {
-        System.out.println(Constants.ENV_LINESEPARATOR
-                + Constants.ENV_LINESEPARATOR + "Roddy is supposed to be a rapid development and management platform for cluster based workflows."
-                + Constants.ENV_LINESEPARATOR + "The current supported ways of execution are:"
-                + Constants.ENV_LINESEPARATOR + " - job submission using qsub with PBS or SGE"
-                + Constants.ENV_LINESEPARATOR + " - monolithic, direct execution of jobs via Roddy"
-                + Constants.ENV_LINESEPARATOR + " - submission or execution on the local machine or via SSH"
-                + Constants.ENV_LINESEPARATOR + Constants.ENV_LINESEPARATOR + "  To support you with your workflows, Roddy offers you several options:" + Constants.ENV_LINESEPARATOR);
+    static void printCommands(List<Object[]> commands) {
+        commands.each { Object[] it ->
+            printCommand(it[0] as RoddyStartupModes, it[1] as String, it[2..-1] as String[])
+        }
+    }
 
-        printCommand(RoddyStartupModes.help, "", "Shows a list of available configuration files in all configured paths.");
-        printCommand(RoddyStartupModes.printappconfig, "[--useconfig={file}]", "Prints the currently loaded application properties ini file.");
-        printCommand(RoddyStartupModes.showconfigpaths, "[--useconfig={file}]", "Shows a list of available configuration files in all configured paths.");
-        printCommand(RoddyStartupModes.showfeaturetoggles, "", "Shows a list of available feature toggles.");
-        printCommand(RoddyStartupModes.prepareprojectconfig, "", "Create or update a project xml file and an application properties ini file.");
-        printCommand(RoddyStartupModes.plugininfo, "[--useconfig={file}]", "Shows details about the available plugins.");
-        printCommand(RoddyStartupModes.printpluginreadme, "(configuration@analysis) [--useconfig={file}]", "Prints the readme file of the currently selected workflow.");
-        printCommand(RoddyStartupModes.printanalysisxml, "(configuration@analysis) [--useconfig={file}]", "Prints the analysis xml file of the currently selected workflow.");
-//        printCommand(RoddyStartupModes.showconfig, "[--useconfig={file}]", "Shows a list of available configuration files in all configured paths.");
-        printCommand(RoddyStartupModes.validateconfig, "(configuration@analysis) [--useconfig={file}]", "Tries to find errors in the specified configuration and shows them.");
-        printCommand(RoddyStartupModes.listworkflows, "[filter word] [--shortlist] [--useconfig={file}]", "Shows a list of available configurations and analyses.", "If a filter word is specified, then the whole configuration tree is only printed", "if at least one configuration id in the tree contains the word.");
-        printCommand(RoddyStartupModes.listdatasets, "(configuration@analysis) [--useconfig={file}]", "Lists the available datasets for a configuration.");
-        printCommand(RoddyStartupModes.printruntimeconfig, "(configuration@analysis) [--useconfig={file}] [--extendedlist] [--showentrysources]", "Basically calls testrun but prints out the converted / prepared runtime configuration script content.", "--extendedlist shows all stored values (also e.g. tool entries. Works only in combination with --showentrysources", "--showentrysources shows the source file of the entry in addition to the value.");
-        printCommand(RoddyStartupModes.testrun, "(configuration@analysis) [pid_0,..,pid_n] [--useconfig={file}]", "Displays the current workflow status for the given datasets.");
-        printCommand(RoddyStartupModes.testrerun, "(configuration@analysis) [pid_0,..,pid_n] [--useconfig={file}]", "Displays the current workflow status for the given datasets.");
-        printCommand(RoddyStartupModes.run, "(configuration@analysis) [pid_0,..,pid_n] [--waitforjobs] [--useconfig={file}]", "Runs a workflow with the configured Jobfactory.", "Does not check if the workflow is already running on the cluster.");
-        printCommand(RoddyStartupModes.rerun, "(configuration@analysis) [pid_0,..,pid_n] [--waitforjobs] [--useconfig={file}]", "Reruns a workflow starting only the parts which did not produce valid files.", "Does not check if the workflow is already running on the cluster.");
-        printCommand(RoddyStartupModes.cleanup, "(configuration@analysis) [pid_0,..,pid_n] [--useconfig={file}]", "Calls a workflows cleanup method or a setup cleanup script to clean (i.e. remove or set to file size zero) output files.");
-        printCommand(RoddyStartupModes.abort, "(configuration@analysis) [pid_0,..,pid_n] [--useconfig={file}]", "Aborts the running jobs of a workflow for a pid.");
+    static void printCommandLineOptions() {
+        System.out.println([
+                Constants.ENV_LINESEPARATOR
+                , "Roddy is supposed to be a rapid development and management platform for cluster based workflows."
+                , "The current supported ways of execution are:"
+                , " - job submission using qsub with PBS or SGE"
+                , " - monolithic, direct execution of jobs via Roddy"
+                , " - submission or execution on the local machine or via SSH"
+                , Constants.ENV_LINESEPARATOR
+                , "  To support you with your workflows, Roddy offers you several options:"].join(Constants.ENV_LINESEPARATOR))
+        System.out.println()
 
-//        printCommand(RoddyStartupModes.rerunstep, "(configuration@analysis) [pid] [--waitforjobs] [--useconfig={file}]", "Reruns a single step of the last execution context.", "The job will be rerun without any dependencies.", "There are no checks if the job is already running.");
-        printCommand(RoddyStartupModes.checkworkflowstatus, "(configuration@analysis) [pid_0,..,pid_n] [--detailed] [--useconfig={file}]", "Shows a generic overview about all datasets for a configuration", "If some datasets are selected, a more detailed output is generated.", "If detailed is set, information about all started jobs and their status is shown.");
-        printCommand(RoddyStartupModes.setup, "[--useconfig={file}]", "Sets up Roddy for command line execution.");
-        printCommand(RoddyStartupModes.ui, "[--useconfig={file}]", "Open Roddys graphical user interface.");
-        println("== Advanced developer options ==\n");
-        printCommand(RoddyStartupModes.compile, "", "Compiles the roddy library / application.");
-        printCommand(RoddyStartupModes.pack, "", "Creates a copy of the current version and puts the version number to the file name.");
-        printCommand(RoddyStartupModes.compileplugin, "(plugin ID) [--useconfig={file}]", "Compiles a plugin .");
-        printCommand(RoddyStartupModes.packplugin, "(plugin ID) [--useconfig={file}]", "Packages the compiled plugin in dist/plugins and creates a version number for it.", "Please note that you can indeed override contents of a zip file if you do not update / compile the plugin jar!");
+        printCommands([
+                [RoddyStartupModes.help, "", "Shows a list of available configuration files in all configured paths."],
+                [RoddyStartupModes.printappconfig, "[--useconfig={file}]", "Prints the currently loaded application properties ini file."],
+                [RoddyStartupModes.showconfigpaths, "[--useconfig={file}]", "Shows a list of available configuration files in all configured paths."],
+                [RoddyStartupModes.showfeaturetoggles, "", "Shows a list of available feature toggles."],
+                [RoddyStartupModes.prepareprojectconfig, "", "Create or update a project xml file and an application properties ini file."],
+                [RoddyStartupModes.plugininfo, "[--useconfig={file}]", "Shows details about the available plugins."],
+                [RoddyStartupModes.printpluginreadme, "(configuration@analysis) [--useconfig={file}]", "Prints the readme file of the currently selected workflow."],
+                [RoddyStartupModes.printanalysisxml, "(configuration@analysis) [--useconfig={file}]", "Prints the analysis xml file of the currently selected workflow."],
+                [RoddyStartupModes.validateconfig, "(configuration@analysis) [--useconfig={file}]", "Tries to find errors in the specified configuration and shows them."],
+                [RoddyStartupModes.listworkflows, "[filter word] [--shortlist] [--useconfig={file}]", "Shows a list of available configurations and analyses.", "If a filter word is specified, then the whole configuration tree is only printed", "if at least one configuration id in the tree contains the word."],
+                [RoddyStartupModes.listdatasets, "(configuration@analysis) [--useconfig={file}]", "Lists the available datasets for a configuration."],
+                [RoddyStartupModes.printruntimeconfig, "(configuration@analysis) [--useconfig={file}] [--extendedlist] [--showentrysources]", "Basically calls testrun but prints out the converted / prepared runtime configuration script content.", "--extendedlist shows all stored values (also e.g. tool entries. Works only in combination with --showentrysources", "--showentrysources shows the source file of the entry in addition to the value."],
+                [RoddyStartupModes.testrun, "(configuration@analysis) [pid_0,..,pid_n] [--useconfig={file}]", "Displays the current workflow status for the given datasets."],
+                [RoddyStartupModes.testrerun, "(configuration@analysis) [pid_0,..,pid_n] [--useconfig={file}]", "Displays the current workflow status for the given datasets."],
+                [RoddyStartupModes.run, "(configuration@analysis) [pid_0,..,pid_n] [--waitforjobs] [--useconfig={file}]", "Runs a workflow with the configured Jobfactory.", "Does not check if the workflow is already running on the cluster."],
+                [RoddyStartupModes.rerun, "(configuration@analysis) [pid_0,..,pid_n] [--waitforjobs] [--useconfig={file}]", "Reruns a workflow starting only the parts which did not produce valid files.", "Does not check if the workflow is already running on the cluster."],
+                [RoddyStartupModes.cleanup, "(configuration@analysis) [pid_0,..,pid_n] [--useconfig={file}]", "Calls a workflows cleanup method or a setup cleanup script to clean (i.e. remove or set to file size zero) output files."],
+                [RoddyStartupModes.abort, "(configuration@analysis) [pid_0,..,pid_n] [--useconfig={file}]", "Aborts the running jobs of a workflow for a pid."],
+                [RoddyStartupModes.checkworkflowstatus, "(configuration@analysis) [pid_0,..,pid_n] [--detailed] [--useconfig={file}]", "Shows a generic overview about all datasets for a configuration", "If some datasets are selected, a more detailed output is generated.", "If detailed is set, information about all started jobs and their status is shown."],
+                [RoddyStartupModes.setup, "[--useconfig={file}]", "Sets up Roddy for command line execution."],
+                [RoddyStartupModes.ui, "[--useconfig={file}]", "Open Roddys graphical user interface."]
+        ] as List<Object[]>)
+
+        println("== Advanced developer options ==\n")
+        printCommands([
+                [RoddyStartupModes.compile, "", "Compiles the roddy library / application."],
+                [RoddyStartupModes.pack, "", "Creates a copy of the current version and puts the version number to the file name."],
+                [RoddyStartupModes.compileplugin, "(plugin ID) [--useconfig={file}]", "Compiles a plugin ."],
+                [RoddyStartupModes.packplugin, "(plugin ID) [--useconfig={file}]", "Packages the compiled plugin in dist/plugins and creates a version number for it.", "Please note that you can indeed override contents of a zip file if you do not update / compile the plugin jar!"]
+        ] as List<Object[]>)
+
         println("================================")
-        System.out.println(Constants.ENV_LINESEPARATOR + Constants.ENV_LINESEPARATOR + "Common additional options");
-        System.out.println("    --useconfig={file}              - Use {file} as the application configuration.\n" +
-                           "    --c={file}                        The order is: full path, .roddy folder, Roddy directory.");
-        System.out.println("    --verbositylevel={1,3,5}        - Set how much Roddy will print to the console, 1 is default, 3 is more, 5 is a lot.\n" +
-                           "    --v                               Set verbosity to 3.\n" +
-                           "    --vv                               Set verbosity to 5.");
-        System.out.println("    --useiodir=[fileIn],{fileOut}   - Use fileIn/fileOut as the base input and output directories for your project.\n" +
-                           "                                      If fileOut is not specified, fileIn is used for that as well.\n" +
-                           "                                      format can be: tsv, csv or excel");
-        System.out.println("    --usemetadatatable={file},[format]\n" +
-                           "                                    - Tell Roddy to use an input table to load metadata and input data and available datasets.\n");
-        System.out.println("    --waitforjobs                   - Let Roddy wait for all submitted jobs to finish.");
-        System.out.println("    --disabletrackonlyuserjobs      - Default for command line mode is that Roddy only tracks user jobs. This can be changed with this switch.");
-        System.out.println("    --useRoddyVersion=(version no)  - Use a specific roddy version.");
-        System.out.println("    --usePluginVersion=(...,...)    - Supply a list of used plugins and versions.");
-        System.out.println("    --configurationDirectories={path},... \n" +
-                           "                                    - Supply a list of configurationdirectories.");
-        System.out.println("    --pluginDirectories={path},...  - Supply a list of plugin directories.");
-        System.out.println(Constants.ENV_LINESEPARATOR + Constants.ENV_LINESEPARATOR + "Roddy version " + Constants.APP_CURRENT_VERSION_STRING + " build at " + Constants.APP_CURRENT_VERSION_BUILD_DATE);
+        System.out.println(Constants.ENV_LINESEPARATOR + Constants.ENV_LINESEPARATOR + "Common additional options")
+        System.out.println([
+                "    --useconfig={file}              - Use {file} as the application configuration.",
+                "    --c={file}                         The order is: full path, .roddy folder, Roddy directory.",
+                "    --verbositylevel={1,3,5}        - Set how much Roddy will print to the console, 1 is default, 3 is more, 5 is a lot.",
+                "    --v                                Set verbosity to 3.",
+                "    --vv                               Set verbosity to 5.",
+                "    --useiodir=[fileIn],{fileOut}   - Use fileIn/fileOut as the base input and output directories for your project.",
+                "                                       If fileOut is not specified, fileIn is used for that as well.",
+                "                                       format can be: tsv, csv or excel",
+                "    --usemetadatatable={file},[format]",
+                "                                    - Tell Roddy to use an input table to load metadata and input data and available datasets.",
+                "    --waitforjobs                   - Let Roddy wait for all submitted jobs to finish.",
+                "    --disabletrackonlyuserjobs      - Default for command line mode is that Roddy only tracks user jobs. This can be changed with this switch.",
+                "    --useRoddyVersion=(version no)  - Use a specific roddy version.",
+                "    --rv=(version no)",
+                "    --usePluginVersion=(...,...)    - Supply a list of used plugins and versions.",
+                "    --configurationDirectories={path},... ",
+                "                                    - Supply a list of configurationdirectories.",
+                "    --pluginDirectories={path},...  - Supply a list of plugin directories."
+        ].join(Constants.ENV_LINESEPARATOR)
+        )
+        System.out.println(Constants.ENV_LINESEPARATOR + Constants.ENV_LINESEPARATOR + "Roddy version " + Constants.APP_CURRENT_VERSION_STRING + " build at " + Constants.APP_CURRENT_VERSION_BUILD_DATE)
     }
 
-    public boolean needsFullInit() {
-        return scope == SCOPE_FULL;
+    boolean needsFullInit() {
+        return scope == SCOPE_FULL
     }
 
     @Override
-    public String toString() {
-        return this.name().replace("_", "");
+    String toString() {
+        return this.name().replace("_", "")
     }
 }

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupOptions.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupOptions.groovy
@@ -53,6 +53,8 @@ public enum RoddyStartupOptions {
     disabletoggles(true),
 
     useRoddyVersion(true),
+    useroddyversion(true),
+    rv(true),
     usePluginVersion(true),
     pluginDirectories(true), 
     configurationDirectories(true),

--- a/RoddyCore/src/de/dkfz/roddy/config/Configuration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/Configuration.java
@@ -104,6 +104,13 @@ public class Configuration implements ContainerParent<Configuration> {
         this.addParent(parentConfig);
     }
 
+    public Configuration(InformationalConfigurationContent informationalConfigurationContent, List<Configuration> parentConfigurations) {
+        this.informationalConfigurationContent = informationalConfigurationContent;
+        for (Configuration parentConfiguration : parentConfigurations) {
+            addParent(parentConfiguration);
+        }
+    }
+
     /**
      * For main configurations
      */

--- a/RoddyCore/src/de/dkfz/roddy/config/Configuration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/Configuration.java
@@ -64,6 +64,11 @@ public class Configuration implements ContainerParent<Configuration> {
      * The prototype with basic information about this configuration
      */
     protected final InformationalConfigurationContent informationalConfigurationContent;
+
+    /**
+     * A list of parent configuration objects. Order matters! Configurations are stored with
+     * increasing priority, so parents[0] has the lowest and parents[n -1] has the highest priority
+     */
     private final List<Configuration> parents = new LinkedList<>();
 
     private final Map<String, Configuration> subConfigurations = new LinkedHashMap<>();
@@ -104,6 +109,13 @@ public class Configuration implements ContainerParent<Configuration> {
         this.addParent(parentConfig);
     }
 
+    /**
+     * @param informationalConfigurationContent
+     * @param parentConfigurations A list of parent configuration objects.
+     *                             Order matters! Configurations are stored with
+     *                             increasing priority, so pcs[0] has the lowest
+     *                             and pcs[n -1] has the highest priority
+     */
     public Configuration(InformationalConfigurationContent informationalConfigurationContent, List<Configuration> parentConfigurations) {
         this.informationalConfigurationContent = informationalConfigurationContent;
         for (Configuration parentConfiguration : parentConfigurations) {
@@ -249,11 +261,20 @@ public class Configuration implements ContainerParent<Configuration> {
         return null;
     }
 
+    /**
+     * Clears the list of parent configuration objects and sets c as the single parent.
+     * @param c
+     */
     public void setParent(Configuration c) {
         parents.clear();
         parents.add(c);
     }
 
+    /**
+     * Add a parent to the parents list. Note, that the added configuration has a higher priority
+     * than the ones already in the list.
+     * @param p
+     */
     public void addParent(Configuration p) {
         if (p == null) return;
         if (!parents.contains(p))

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.java
@@ -35,7 +35,6 @@ public class ConfigurationValue implements RecursiveOverridableMapContainer.Iden
     public final String value;
     private final Configuration configuration;
     private final String type;
-    private boolean quoteOnConversion;
 
     /**
      * A description or comment for a configuration value.

--- a/RoddyCore/src/de/dkfz/roddy/config/ContextConfiguration.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ContextConfiguration.java
@@ -21,8 +21,6 @@ public class ContextConfiguration extends AnalysisConfiguration {
         this.projectConfiguration = projectConfiguration;
         addParent(analysisConfiguration);
         addParent(projectConfiguration);
-//        for(Configuration c : configuration.getContainerParents())
-//            addParent(c);
     }
 
     public AnalysisConfiguration getAnalysisConfiguration() {

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainer.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainer.java
@@ -18,8 +18,6 @@ import java.util.Map;
  */
 public class RecursiveOverridableMapContainer<K, V extends RecursiveOverridableMapContainer.Identifiable, P extends ContainerParent> {
 
-
-
     public interface Identifiable {
         String getID();
     }
@@ -28,7 +26,6 @@ public class RecursiveOverridableMapContainer<K, V extends RecursiveOverridableM
      * A list of values in this container's configuration
      */
     protected final Map<K, V> values = new LinkedHashMap<>();
-
 
     private final P containerParent;
 
@@ -123,8 +120,7 @@ public class RecursiveOverridableMapContainer<K, V extends RecursiveOverridableM
      * @param src
      * @return
      */
-    protected V copyValueToThisContainer(V src) {
-        add(src);
+    protected V temporarilyElevateValue(V src) {
         return src;
     }
 
@@ -136,7 +132,7 @@ public class RecursiveOverridableMapContainer<K, V extends RecursiveOverridableM
     protected V _getValueUnchecked(String id) {
         V cval = getAllValues().get(id);
         if(!values.containsKey(id))
-            return copyValueToThisContainer(cval);
+            return temporarilyElevateValue(cval);
 
         return cval;
     }

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
@@ -41,6 +41,13 @@ public class RecursiveOverridableMapContainerForConfigurationValues extends Recu
         return hasValue(id) ? getValue(id).toBoolean() : b;
     }
 
+    @Override
+    protected ConfigurationValue copyValueToThisContainer(ConfigurationValue src) {
+        ConfigurationValue cpy = new ConfigurationValue(this.getContainerParent(), src.id, src.value, src.getType(), src.getDescription(), new LinkedList<>(src.getListOfTags()));
+        add(cpy);
+        return cpy;
+    }
+
     /**
      * Returns the value converted to a string or an empty string ("") if the value could not be found.
      *
@@ -65,5 +72,6 @@ public class RecursiveOverridableMapContainerForConfigurationValues extends Recu
     public void put(String id, String value, String type) {
         super.add(new ConfigurationValue(id, value, type));
     }
+
 
 }

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.java
@@ -108,7 +108,11 @@ public class Analysis {
         }
     }
 
-
+    /**
+     * The object should actually move to context itself. However, currently, this would break a lot.
+     * Mark it as Deprecated for now.
+     */
+    @Deprecated
     private ContextConfiguration _contextConfiguration = null;
 
     public Configuration getConfiguration() {

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
@@ -289,6 +289,14 @@ class ExecutionContext {
         return analysis.getConfiguration()
     }
 
+    Configuration getJobConfiguration(Job job) {
+
+    }
+
+    Configuration getFileConfiguration(BaseFile baseFile) {
+
+    }
+
     RecursiveOverridableMapContainerForConfigurationValues getConfigurationValues() {
         return configuration.getConfigurationValues()
     }

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
@@ -688,46 +688,6 @@ public class Job {
         return lastCommand;
     }
 
-//    private transient final Deque<JobStatusListener> listeners = new ConcurrentLinkedDeque<>();
-//
-//    public void addJobStatusListener(JobStatusListener listener, boolean replaceOfSameClass) {
-//        //TODO Synchronize
-//        if (replaceOfSameClass) {
-//            Class c = listener.getClass();
-//            Deque<JobStatusListener> listenersToKeep = new ConcurrentLinkedDeque<>();
-//            for (JobStatusListener jsl : this.listeners) {
-//                if (jsl.getClass() != c)
-//                    listenersToKeep.add(jsl);
-//            }
-//            listeners.clear();
-//            listeners.addAll(listenersToKeep);
-//        }
-//        addJobStatusListener(listener);
-//    }
-//
-//    public void addJobStatusListener(JobStatusListener listener) {
-//        synchronized (listeners) {
-//            if (this.listeners.contains(listener)) return;
-//            this.listeners.add(listener);
-//        }
-//    }
-//
-//    private void fireJobStatusChangedEvent(JobState old, JobState newState) {
-//        //TODO Synchronize
-//        if (old == newState) return;
-//        for (JobStatusListener jsl : listeners)
-//            jsl.jobStatusChanged(this, old, newState);
-//    }
-//
-//    public void removeJobStatusListener(JobStatusListener listener) {
-//        if (listener == null)
-//            return;
-//        synchronized (listeners) {
-//            if (this.listeners.contains(listener))
-//                this.listeners.remove(listener);
-//        }
-//    }
-
     public Map<String, String> getParameters() {
         return parameters;
     }

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStage.java
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/FileStage.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 /**
 */
+@Deprecated
 public class FileStage {
 
     private static final List<FileStage> listOfAvailableFileStages = new LinkedList<>();

--- a/RoddyCore/test/de/dkfz/roddy/config/ConfigurationValueInheritanceTests.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/ConfigurationValueInheritanceTests.groovy
@@ -10,14 +10,15 @@ import groovy.transform.CompileStatic
 import org.junit.Test
 
 /**
+ * Test cases for configuration and configuration value inheritance
  * Created by heinold on 14.07.16.
  */
 @CompileStatic
-class ConfigurationValueTest {
+class ConfigurationValueInheritanceTests {
 
     /**
      * Given are two configurations:
-     * C extends B, B extends A
+     * B extends A
      * =>   A -> B
      *
      * Configurations contain variables a and b
@@ -82,6 +83,10 @@ class ConfigurationValueTest {
 
     /**
      * Test a complex hierarchy
+     * C1 extends B1 and B2, B1 extends A1 and A2
+     * B2 has a higher priority than B1
+     * A2 has a higher priority than A1
+     *
      * =>   {{A1, A2} -> B1, B2} -> C1
      *
      * A1 = { a = 'A1.a', b = '${a}' }              <br/> Idea will try to pull A B C on the same line on code format.
@@ -97,7 +102,7 @@ class ConfigurationValueTest {
      * B1.b = 'A2.b'
      * B1.d = 'A2.a'
      *
-     * B2.a = 'B2.b + ${c}'
+     * B2.a = 'B2.b + ${c}'     c is not set in A* or B* and therefore will not be evaluated
      *
      * C1.a = 'B2.b + C.c'
      * C1.b = 'B2.b'

--- a/RoddyCore/test/de/dkfz/roddy/config/ConfigurationValueTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/ConfigurationValueTest.groovy
@@ -15,36 +15,49 @@ import org.junit.Test
 @CompileStatic
 class ConfigurationValueTest {
 
+    /**
+     * Given are two configurations:
+     * C extends B, B extends A
+     * =>   A -> B
+     *
+     * Configurations contain variables a and b
+     * A = { a = 'abc', b = 'abc${a}' }         <br/> Idea will try to pull A B C on the same line on code format.
+     * B = { a = 'def' }                        <br/>
+     * expected C.b = 'klm'
+     * expected B.b = 'hij'
+     */
     @Test
-    public void testCValueSubstitutionWithCfgDualChain() {
-        // Two dependent values in base cfg
-        // Overriden in extended cfg
+    void testCValueSubstitutionWithCfgDualChain() {
+        Configuration A = new Configuration(null)
+        Configuration B = new Configuration(null, A)
 
-        Configuration cfgBase = new Configuration(null)
-        Configuration cfgExt = new Configuration(null, cfgBase)
+        def cvA = A.getConfigurationValues()
+        def cvB = B.getConfigurationValues()
 
-        def cvBase = cfgBase.getConfigurationValues()
-        def cvExt = cfgExt.getConfigurationValues()
+        cvA.put('a', 'abc')
+        cvA.put('b', 'abc${a}')
 
-        cvBase << new ConfigurationValue(cfgBase, "a", "abc")
-        cvBase << new ConfigurationValue(cfgBase, "b", 'abc${a}')
+        cvB.put('a', 'def')
 
-        cvExt << new ConfigurationValue(cfgExt, "a", "def")
-
-        assert cvExt["a"].value == "def"
-        assert cvExt["b"].value == 'abc${a}'
-        assert cvExt["b"].toString() == "abcdef"
+        assert cvB['a'].value == 'def'
+        assert cvB['b'].value == 'abc${a}'
+        assert cvB['b'].toString() == 'abcdef'
     }
 
     /**
-     * A = { a = "abc", b = "def" }
-     * B = { a = "hij", b = "$a" }
-     * C = { a = "klm" }
-     * C.b = "klm"
-     * B.b = "hij"
+     * Given are three configurations:
+     * C extends B, B extends A
+     * =>   A -> B -> C
+     *
+     * Configurations contain variables a and b
+     * A = { a = 'abc', b = 'def' }             <br/> Idea will try to pull A B C on the same line on code format.
+     * B = { a = 'hij', b = '$a' }              <br/>
+     * C = { a = 'klm' }                        <br/>
+     * expected C.b = 'klm'
+     * expected B.b = 'hij'
      */
     @Test
-    public void testCValueSubstitutionWithCfgTripleChain() {
+    void testCValueSubstitutionWithCfgTripleChain() {
         Configuration A = new Configuration(null)
         Configuration B = new Configuration(null, A)
         Configuration C = new Configuration(null, B)
@@ -53,17 +66,84 @@ class ConfigurationValueTest {
         def cvB = B.getConfigurationValues()
         def cvC = C.getConfigurationValues()
 
-        cvA << new ConfigurationValue(A, "a", "abc")
-        cvA << new ConfigurationValue(A, "b", 'def')
+        cvA.put('a', 'abc')
+        cvA.put('b', 'def')
 
-        cvB << new ConfigurationValue(B, "a", "hij")
-        cvB << new ConfigurationValue(B, "b", '${a}')
+        cvB.put('a', 'hij')
+        cvB.put('b', '${a}')
 
-        cvC << new ConfigurationValue(C, "a", "klm")
+        cvC.put('a', 'klm')
 
-        assert cvB["a"].value == "hij"
-        assert cvB["b"].value == '${a}'
-        assert cvB["b"].toString() == "hij"
-        assert cvC["b"].toString() == "klm"
+        assert cvB['a'].value == 'hij'
+        assert cvB['b'].value == '${a}'
+        assert cvB['b'].toString() == 'hij'
+        assert cvC['b'].toString() == 'klm'
+    }
+
+    /**
+     * Test a complex hierarchy
+     * =>   {{A1, A2} -> B1, B2} -> C1
+     *
+     * A1 = { a = 'A1.a', b = '${a}' }              <br/> Idea will try to pull A B C on the same line on code format.
+     * A2 = { a = 'A2.a', b = 'A2.b' }              <br/>
+     * B1 = { c = 'B1.c', b = '${a}' }              <br/>
+     * B2 = { a = '${b} + ${c}', b = 'B2.b' }       <br/>
+     * C1 = { c = 'C.c' }                           <br/>
+     *
+     * A1.b = 'A1.a'
+     * A2.b = 'A2.b'
+     *
+     * B1.a = 'A2.a'
+     * B1.b = 'A2.b'
+     * B1.d = 'A2.a'
+     *
+     * B2.a = 'B2.b + ${c}'
+     *
+     * C1.a = 'B2.b + C.c'
+     * C1.b = 'B2.b'
+     * C1.c = 'C.c'
+     * C1.d = 'B2.b + C.c'
+     */
+    @Test
+    void testCValueSubstitutionWithComplexHierarchy() {
+        Configuration A1 = new Configuration(null)
+        Configuration A2 = new Configuration(null)
+        Configuration B1 = new Configuration(null, [A1, A2])
+        Configuration B2 = new Configuration(null)
+        Configuration C = new Configuration(null, [B1, B2])
+
+        def cvA1 = A1.configurationValues
+        def cvA2 = A2.configurationValues
+        def cvB1 = B1.configurationValues
+        def cvB2 = B2.configurationValues
+        def cvC1 = C.configurationValues
+
+        cvA1.put('a', 'A1.a')
+        cvA1.put('b', '${a}')
+
+        cvA2.put('a', 'A2.a')
+        cvA2.put('b', 'A2.b')
+
+        cvB1.put('c', 'B1.c')
+        cvB1.put('d', '${a}')
+
+        cvB2.put('a', '${b} + ${c}')
+        cvB2.put('b', 'B2.b')
+
+        cvC1.put('c', 'C.c')
+
+        assert cvA1['b'].toString() == 'A1.a'
+        assert cvA2['b'].toString() == 'A2.b'
+
+        assert cvB1['a'].toString() == 'A2.a'
+        assert cvB1['b'].toString() == 'A2.b'
+        assert cvB1['d'].toString() == 'A2.a'
+
+        assert cvB2['a'].toString() == 'B2.b + ${c}'   // c cannot be resolved and will stay as it is.
+
+        assert cvC1['a'].toString() == 'B2.b + C.c'
+        assert cvC1['b'].toString() == 'B2.b'
+        assert cvC1['c'].toString() == 'C.c'
+        assert cvC1['d'].toString() == 'B2.b + C.c'
     }
 }

--- a/RoddyCore/test/de/dkfz/roddy/config/ConfigurationValueTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/ConfigurationValueTest.groovy
@@ -13,15 +13,26 @@ import org.junit.Test
  * Created by heinold on 14.07.16.
  */
 @CompileStatic
-class ConfigurationValueTest extends GroovyTestCase {
-
-    // Test for determineTypeOfValue is in RoddyConversionHelperMethodsTest.groovy
-    // The method is directly bound to several methods of the conversion class and has nearly no
-    // logic of its own. So we put it there.
+class ConfigurationValueTest {
 
     @Test
-    public void testNothing() {
-        // Asimple test so the class really fails.
-        assert false
+    public void testCValueSubstitutionWithCfgDuo() {
+        // Two dependent values in base cfg
+        // Overriden in extended cfg
+
+        Configuration cfgBase = new Configuration(null)
+        Configuration cfgExt = new Configuration(null, cfgBase)
+
+        def cvBase = cfgBase.getConfigurationValues()
+        def cvExt = cfgExt.getConfigurationValues()
+
+        cvBase << new ConfigurationValue(cfgBase, "a", "abc")
+        cvBase << new ConfigurationValue(cfgBase, "b", 'abc${a}')
+
+        cvExt << new ConfigurationValue(cfgExt, "a", "def")
+
+        assert cvExt["a"].value == "def"
+        assert cvExt["b"].value == 'abc${a}'
+        assert cvExt["b"].toString() == "abcdef"
     }
 }

--- a/RoddyCore/test/de/dkfz/roddy/config/ConfigurationValueTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/ConfigurationValueTest.groovy
@@ -16,7 +16,7 @@ import org.junit.Test
 class ConfigurationValueTest {
 
     @Test
-    public void testCValueSubstitutionWithCfgDuo() {
+    public void testCValueSubstitutionWithCfgDualChain() {
         // Two dependent values in base cfg
         // Overriden in extended cfg
 
@@ -34,5 +34,36 @@ class ConfigurationValueTest {
         assert cvExt["a"].value == "def"
         assert cvExt["b"].value == 'abc${a}'
         assert cvExt["b"].toString() == "abcdef"
+    }
+
+    /**
+     * A = { a = "abc", b = "def" }
+     * B = { a = "hij", b = "$a" }
+     * C = { a = "klm" }
+     * C.b = "klm"
+     * B.b = "hij"
+     */
+    @Test
+    public void testCValueSubstitutionWithCfgTripleChain() {
+        Configuration A = new Configuration(null)
+        Configuration B = new Configuration(null, A)
+        Configuration C = new Configuration(null, B)
+
+        def cvA = A.getConfigurationValues()
+        def cvB = B.getConfigurationValues()
+        def cvC = C.getConfigurationValues()
+
+        cvA << new ConfigurationValue(A, "a", "abc")
+        cvA << new ConfigurationValue(A, "b", 'def')
+
+        cvB << new ConfigurationValue(B, "a", "hij")
+        cvB << new ConfigurationValue(B, "b", '${a}')
+
+        cvC << new ConfigurationValue(C, "a", "klm")
+
+        assert cvB["a"].value == "hij"
+        assert cvB["b"].value == '${a}'
+        assert cvB["b"].toString() == "hij"
+        assert cvC["b"].toString() == "klm"
     }
 }


### PR DESCRIPTION
The method performInitialCheck() in Roddy.java is introduced. Currently
it checks for existens of jar/zip/unzip using which! Not ideal but a
start.

There was a bug for configuration values:
     * When you have several configuration objects, e.g.
     * A -> B
     *
     * A contains values a and b, where a == abc and b has a reference
     * to a b=${a}
     * B contains values a'  == def
     * If you query B for b, b holds a reference to configuration A
     * Therefore, b.toString() will result in b == abc and NOT in def as
     * expected.
     *
     * By elevating a copy of b to B, everything will be fixed, as B can
     * be the parent of b'
     *
     * This is true for ConfigurationValue, which rely on dependencies
     * between themselves.
     *
     * In RecursiveOverridableMapContainerForConfigurationValues, we
     * override the method and
     * copy the value and set the configuration reference to (in this
     * example) B

Add --rv for --useRoddyVersion, rework help message