### PR TITLE
Bugfix for FG output, Cleanup and enhance FilenamePattern(Test)

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.java
@@ -284,7 +284,7 @@ public class ConfigurationValue implements RecursiveOverridableMapContainer.Iden
         List<String> parentValues = new LinkedList<>();
 
         Matcher m = variableDetection.matcher(value);
-//            Findall is not available in standard java, so I use groovy here.
+        // Findall is not available in standard java, so I use groovy here.
         for (String s : ConfigurationValueHelper.callFindAllForPatternMatcher(m)) {
             String vName = s.replaceAll("[${}]", "");
             parentValues.add(vName);

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePattern.java
@@ -18,6 +18,8 @@ import java.lang.reflect.Method;
 import de.dkfz.roddy.config.FilenamePatternHelper.Command;
 import de.dkfz.roddy.config.FilenamePatternHelper.CommandAttribute;
 
+import static de.dkfz.roddy.StringConstants.EMPTY;
+
 /**
  * Filename patterns are stored in a configuration file. They are project specific and should be fully configurable.
  */
@@ -72,18 +74,91 @@ public abstract class FilenamePattern implements RecursiveOverridableMapContaine
 
     public abstract FilenamePatternDependency getFilenamePatternDependency();
 
-    protected String fillVariables(BaseFile baseFile, String temp) {
-        ExecutionContext context = baseFile.getExecutionContext();
+    protected BaseFile getSourceFile(BaseFile[] baseFiles) {
+        return null;
+    }
+
+    /**
+     * Fills special values collected from the first parent file.
+     * <p>
+     * ${sourcefile}                            - Full name and path
+     * ${sourcefileAtomic}                      - Only the name
+     * ${sourcefileProperty,[VALUE]}            - Call a property from the source files.
+     * The method tries to assemble the property getter name: get[Uppercase:V]alue
+     * retrieve this via reflection and call it.
+     * ${sourcefileAtomicPrefix,[delimiter]}    - Name of the source file until first occurrence of delimiter
+     * ${sourcepath}                            - The path of the source file
+     *
+     * @param temp
+     * @param baseFiles
+     * @return
+     * @throws Exception
+     */
+    String fillValuesFromSourceFile(String temp, BaseFile[] baseFiles) throws Exception {
+        BaseFile baseFile = baseFiles[0];
+        BaseFile sourceFile = getSourceFile(baseFiles);
+        if (sourceFile != null) {
+            File sourcepath = sourceFile.getPath();
+            temp = temp.replace("${sourcefile}", sourcepath.getAbsolutePath());
+            temp = temp.replace("${sourcefileAtomic}", sourcepath.getName());
+            if (temp.contains(PLACEHOLDER_SOURCEFILE_PROPERTY)) { //Replace the string with a property value
+                Command command = FilenamePatternHelper.extractCommand(baseFile.getExecutionContext(), PLACEHOLDER_SOURCEFILE_PROPERTY, temp);
+                String pName = command.attributes.keySet().toArray()[0].toString();
+
+                String accessorName = "get" + pName.substring(0, 1).toUpperCase() + pName.substring(1);
+                Method accessorMethod = sourceFile.getClass().getMethod(accessorName);
+                String value = accessorMethod.invoke(sourceFile).toString();
+                temp = temp.replace(command.fullString, value);
+            }
+
+            if (temp.contains(PLACEHOLDER_SOURCEFILE_ATOMIC_PREFIX)) {
+                Command command = FilenamePatternHelper.extractCommand(baseFile.getExecutionContext(), PLACEHOLDER_SOURCEFILE_ATOMIC_PREFIX, temp);
+                CommandAttribute att = command.attributes.get("delimiter");
+                if (att != null) {
+                    String sourcename = sourcepath.getName();
+                    temp = temp.replace(command.fullString, sourcename.substring(0, sourcename.lastIndexOf(att.value)));
+                }
+            }
+
+            temp = temp.replace("${sourcepath}", sourcepath.getParent());
+
+        }
+        return temp;
+    }
+
+    /**
+     * Will be put to the file base configuration
+     *
+     * @param temp
+     * @param baseFile
+     * @return
+     */
+    @Deprecated
+    String fillFileGroupIndex(String temp, BaseFile baseFile) {
+        if (baseFile.hasIndexInFileGroup())
+            temp = temp.replace("${fgindex}", baseFile.getIdxInFileGroup());
+        return temp;
+    }
+
+    /**
+     * Should this not be part of the variable replacement?
+     *
+     * @param src
+     * @param context
+     * @return
+     */
+    @Deprecated
+    String fillDirectories(String src, ExecutionContext context) {
         Configuration cfg = context.getConfiguration();
 
         //Different output folder
         String oPath = context.getOutputDirectory().getAbsolutePath();
-        temp = temp.replace("${outputAnalysisBaseDirectory}", oPath);
+        src = src.replace("${outputAnalysisBaseDirectory}", oPath);
 
         //Replace output directories containing OutputDirectory
         final String odComp = "OutputDirectory";
-        if (temp.contains(odComp)) {
-            String[] split = temp.split(File.separator);
+        if (src.contains(odComp)) {
+            String[] split = src.split(File.separator);
             for (String s : split) {
                 if (s.contains(odComp)) {
                     String cvalID = s.substring(2, s.length() - 1);
@@ -91,32 +166,75 @@ public abstract class FilenamePattern implements RecursiveOverridableMapContaine
 
                     String pathSup = cval.getType().equals("path") ? cval.toFile(context).getAbsolutePath() : cval.toString();
                     pathSup = pathSup.replace(Roddy.getApplicationDirectory().getAbsolutePath() + "/", ""); //Remove Roddy application folder from path...
-                    temp = temp.replace(s, pathSup);
+                    src = src.replace(s, pathSup);
                 }
             }
         }
-
-        while (temp.contains(PLACEHOLDER_CVALUE)) {
-            Command command = FilenamePatternHelper.extractCommand(context, PLACEHOLDER_CVALUE, temp);
-            CommandAttribute name = command.attributes.get("name");
-            CommandAttribute def = command.attributes.get("default");
-            if (name != null) {
-                ConfigurationValue cv = null;
-
-                if (def != null)
-                    cv = cfg.getConfigurationValues().get(name.value, def.value);
-                else
-                    cv = cfg.getConfigurationValues().get(name.value);
-
-                if (cv != null) {
-                    temp = temp.replace(command.name, cv.toString());
-                }
-            }
-        }
-        return temp;
+        return src;
     }
 
-    protected String fillVariablesFromSourceFileValues(BaseFile baseFile, String temp) {
+    /**
+     * Effectively try to resolve all the unresolved variables and ${cvalue,} marked variables
+     *
+     * @param src
+     * @param context
+     * @return
+     */
+    String fillConfigurationVariables(String src, ExecutionContext context) {
+        Configuration cfg = context.getConfiguration();
+        boolean somethingChanged = true;
+        RecursiveOverridableMapContainerForConfigurationValues configurationValues = cfg.getConfigurationValues();
+        while (src.contains(PLACEHOLDER_CVALUE) && somethingChanged) {
+            somethingChanged = true;
+            String oldValue = src;
+            Command command = FilenamePatternHelper.extractCommand(context, PLACEHOLDER_CVALUE, src);
+            CommandAttribute name = command.attributes.get("name");
+            CommandAttribute defaultValue = command.attributes.get("default");
+            if (name != null) {
+                ConfigurationValue cv;
+
+                if (defaultValue != null) {
+                    // If a default value is set, get the cvalue with the alternate default value.
+                    cv = configurationValues.get(name.value, defaultValue.value);
+                } else if (configurationValues.hasValue(name.value)) {
+                    // If there is no default value set, a default one with "null" as the value might be returned.
+                    // If it is null, set the cv to null.
+                    cv = configurationValues.get(name.value, null);
+                } else {
+                    cv = null;
+                }
+
+                if (cv != null) {
+                    // Available, non-null values will be inserted.
+                    src = src.replace(command.fullString, cv.toString());
+                } else {
+                    // Log out a message, that a variable was not found and leave in the original value.
+                    // In some cases, this is appropriate (like for parameters).
+                    logger.postSometimesInfo("A variable could not be resolved " + command.rawName + " for a filename pattern. Replace part with the variable name.");
+                    src = src.replace(command.fullString, "${" + command.rawName + "}");
+                }
+            }
+            somethingChanged = !oldValue.equals(src);
+        }
+
+        /** Try and resolve the leftofer ${someKindOfValue}, stop, when nothing changed. **/
+        somethingChanged = true;
+        while (src.contains("${") && somethingChanged) {
+            somethingChanged = false; //Reset
+            Command command = FilenamePatternHelper.extractCommand(context, EMPTY, src);
+
+            // The simple form for cvalue substitution does not allow name, default or other tags.
+            String oldValue = src;
+            // Only change it, if the value is in the configuration.
+            if(configurationValues.hasValue(command.rawName)) {
+                src = src.replace(command.fullString, configurationValues.get(command.rawName).toString());
+            }
+            if (oldValue != src) somethingChanged = true;
+        }
+        return src;
+    }
+
+    String fillVariablesFromSourceFileValues(BaseFile baseFile, String temp) {
         FileStageSettings fs = baseFile.getFileStage();
         String _temp = temp;
         if (fs != null)
@@ -131,18 +249,21 @@ public abstract class FilenamePattern implements RecursiveOverridableMapContaine
         return temp;
     }
 
-    protected String fillVariablesFromSourceFileArrayValues(BaseFile baseFile, String temp, int index) {
-        FileStageSettings fs = baseFile.getFileStage();
-        //pid, sample, run...
-        temp = temp.replace(String.format("${fileStageID[%d]}", index), fs.getIDString());
-        temp = temp.replace(String.format("${pid[%d]}", index), baseFile.getDataSet().toString()); // TODO: Move to plugin.
-        temp = temp.replace(String.format("${dataSet[%d]}", index), baseFile.getDataSet().toString());
-        temp = fs.fillStringContentWithArrayValues(index, temp);
-        return temp;
-    }
+    String fillVariablesFromSourceFileArrayValues(BaseFile[] baseFiles, String src) {
+        if (!acceptsFileArrays || (enforcedArraySize != -1 && (enforcedArraySize == -1 || enforcedArraySize != baseFiles.length))) {
+            return src;
+        }
+        for (int i = 0; i < baseFiles.length; i++) {
+            BaseFile baseFile = baseFiles[i];
 
-    protected BaseFile getSourceFile(BaseFile[] baseFiles) {
-        return null;
+            //PID / Dataset id and filestage
+            FileStageSettings fs = baseFile.getFileStage();
+            src = src.replace(String.format("${fileStageID[%d]}", i), fs.getIDString());
+            src = src.replace(String.format("${pid[%d]}", i), baseFile.getDataSet().toString()); // TODO: Move to plugin.
+            src = src.replace(String.format("${dataSet[%d]}", i), baseFile.getDataSet().toString());
+            src = fs.fillStringContentWithArrayValues(i, src);
+        }
+        return src;
     }
 
     /**
@@ -165,54 +286,24 @@ public abstract class FilenamePattern implements RecursiveOverridableMapContaine
      */
     public String apply(BaseFile[] baseFiles) {
 
-        String temp = null;
+        String temp = pattern;
         try {
-            temp = null;
             BaseFile baseFile = baseFiles[0];
-            BaseFile sourceFile = getSourceFile(baseFiles);
-            temp = pattern;
 
             // There is one source file existing, so source file based options can be applied.
-            if (sourceFile != null) {
-                File sourcepath = sourceFile.getPath();
-                temp = temp.replace("${sourcefile}", sourcepath.getAbsolutePath());
-                temp = temp.replace("${sourcefileAtomic}", sourcepath.getName());
-                if (temp.contains(PLACEHOLDER_SOURCEFILE_PROPERTY)) { //Replace the string with a property value
-                    Command command = FilenamePatternHelper.extractCommand(baseFile.getExecutionContext(), PLACEHOLDER_SOURCEFILE_PROPERTY, temp);
-                    String pName = command.attributes.keySet().toArray()[0].toString();
-
-                    String accessorName = "get" + pName.substring(0, 1).toUpperCase() + pName.substring(1);
-                    Method accessorMethod = sourceFile.getClass().getMethod(accessorName);
-                    String value = accessorMethod.invoke(sourceFile).toString();
-                    temp = temp.replace(command.name, value);
-                }
-                if (temp.contains(PLACEHOLDER_SOURCEFILE_ATOMIC_PREFIX)) {
-                    Command command = FilenamePatternHelper.extractCommand(baseFile.getExecutionContext(), PLACEHOLDER_SOURCEFILE_ATOMIC_PREFIX, temp);
-                    CommandAttribute att = command.attributes.get("delimiter");
-                    if (att != null) {
-                        String sourcename = sourcepath.getName();
-                        temp = temp.replace(command.name, sourcename.substring(0, sourcename.lastIndexOf(att.value)));
-                    }
-                }
-
-                temp = temp.replace("${sourcepath}", sourcepath.getParent());
-                if (acceptsFileArrays && (enforcedArraySize == -1 || (enforcedArraySize != -1 && enforcedArraySize == baseFiles.length)))
-                    for (int i = 0; i < baseFiles.length; i++) {
-                        temp = fillVariablesFromSourceFileArrayValues(baseFiles[i], temp, i);
-                    }
-
-            }
-
-            if(baseFile.hasIndexInFileGroup())
-                temp = temp.replace("${fgindex}", baseFile.getIdxInFileGroup());
-
-            temp = fillVariables(baseFile, temp);
+            temp = fillValuesFromSourceFile(temp, baseFiles);
+            temp = fillFileGroupIndex(temp, baseFile);
+            temp = fillDirectories(temp, baseFile.getExecutionContext());
+            temp = fillConfigurationVariables(temp, baseFile.getExecutionContext());
             temp = fillVariablesFromSourceFileValues(baseFile, temp);
+            temp = fillVariablesFromSourceFileArrayValues(baseFiles, temp);
+
         } catch (Exception e) {
             logger.severe("Could not apply filename pattern " + pattern + " for file " + baseFiles[0]);
             e.printStackTrace();
         }
         return temp;
     }
+
 
 }

--- a/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/FilenamePatternHelper.groovy
@@ -8,11 +8,9 @@ package de.dkfz.roddy.config
 
 import de.dkfz.roddy.core.ExecutionContext
 import de.dkfz.roddy.core.ExecutionContextError
-import de.dkfz.roddy.knowledge.files.BaseFile
 import groovy.transform.CompileStatic
 
 import static de.dkfz.roddy.StringConstants.BRACE_RIGHT
-import static de.dkfz.roddy.StringConstants.EMPTY
 import static de.dkfz.roddy.StringConstants.EMPTY
 import static de.dkfz.roddy.StringConstants.SPLIT_COMMA
 import static de.dkfz.roddy.StringConstants.SPLIT_EQUALS
@@ -24,11 +22,13 @@ import static de.dkfz.roddy.StringConstants.SPLIT_EQUALS
 class FilenamePatternHelper {
 
     public static class Command {
-        public final String name;
+        public final String rawName
+        public final String fullString
         public final Map<String, CommandAttribute> attributes = new HashMap<String, CommandAttribute>();
 
-        public Command(String name, Map<String, CommandAttribute> attributes) {
-            this.name = name;
+        public Command(String fullString, Map<String, CommandAttribute> attributes) {
+            this.fullString = fullString;
+            this.rawName = fullString[2 .. -2].split(",")[0]
             if (attributes != null)
                 this.attributes.putAll(attributes);
         }
@@ -45,6 +45,8 @@ class FilenamePatternHelper {
     }
 
     public static Command extractCommand(ExecutionContext context, String commandID, String temp, int startIndex = -1) {
+        if (!commandID.startsWith('${'))
+            commandID = '${' + commandID
         if (startIndex == -1)
             startIndex = temp.indexOf(commandID);
         int endIndex = temp.indexOf(BRACE_RIGHT, startIndex);
@@ -74,7 +76,7 @@ class FilenamePatternHelper {
         ]
 
         // Check if the attribute at least has a name tag
-        if (commandsWithNameTags.find { command.startsWith(it) } && !attributes["name"] ) {
+        if (commandsWithNameTags.find { command.startsWith(it) } && !attributes["name"]) {
             context.addErrorEntry(ExecutionContextError.EXECUTION_SETUP_INVALID.expand("The jobParameter for ${command} must have a name tag with a value."))
         }
 

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/methods/GenericMethod.groovy
@@ -418,7 +418,7 @@ class GenericMethod {
             if (!outputFileGroupIndices) {
                 throw new RuntimeException("A tool which outputs a filegroup with index values needs to be called properly! Pass index values in the call.")
             }
-            ToolFileParameter autoToolFileParameter = new ToolFileParameter(tfg.genericFileClass, [], "AFILEGROUP", new ToolFileParameterCheckCondition(true))
+            ToolFileParameter autoToolFileParameter = new ToolFileParameter(tfg.genericFileClass, [], tfg.scriptParameterName, new ToolFileParameterCheckCondition(true))
             for (Object index in outputFileGroupIndices) {
                 BaseFile bf = convertToolFileParameterToBaseFile(autoToolFileParameter, index.toString())
                 filesInGroup << bf

--- a/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternHelperTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternHelperTest.groovy
@@ -8,14 +8,14 @@ package de.dkfz.roddy.config
 
 import de.dkfz.roddy.core.ExecutionContext
 import de.dkfz.roddy.core.MockupExecutionContextBuilder
+import groovy.transform.CompileStatic
 import org.junit.BeforeClass
 import org.junit.Test
-
-import static org.junit.Assert.*
 
 /**
  * Created by heinold on 10.01.17.
  */
+@CompileStatic
 class FilenamePatternHelperTest {
 
     static ExecutionContext mockupContext
@@ -30,6 +30,24 @@ class FilenamePatternHelperTest {
         assert mockupContext
     }
 
+    @Test
+    void extractEmptyCommand() {
+        // Extract empty command means to detect something unknown inside ${ .. }
+        def val = 'abc${value}def'
+        def result = FilenamePatternHelper.extractCommand(mockupContext, "", val)
+        assert result.rawName == "value"
+    }
+
+    @Test
+    void extractRegularCommand() {
+        // Extract empty command means to detect something unknown inside ${ .. }
+        def val = 'abc${cvalue,name="value"}def'
+        def result = FilenamePatternHelper.extractCommand(mockupContext, '\${cvalue', val)
+        assert result.rawName == "cvalue"
+        assert result.fullString == '${cvalue,name="value"}'
+        assert result.attributes.size() == 1
+        assert result.attributes["name"].value == "value"
+    }
 
     @Test
     void extractCommands() throws Exception {

--- a/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/config/FilenamePatternTest.groovy
@@ -22,7 +22,7 @@ import de.dkfz.roddy.knowledge.methods.GenericMethod
 import de.dkfz.roddy.knowledge.nativeworkflows.GenericJobInfo
 import de.dkfz.roddy.plugins.LibrariesFactory
 import de.dkfz.roddy.plugins.LibrariesFactoryTest
-import org.junit.BeforeClass;
+import org.junit.BeforeClass
 
 import java.io.*
 
@@ -33,62 +33,62 @@ import org.junit.Test
  * Created by heinold on 07.01.2016.
  */
 @groovy.transform.CompileStatic
-public class FilenamePatternTest {
-    public static ExecutionContext mockedContext;
+class FilenamePatternTest {
+    public static ExecutionContext mockedContext
 
     private static Class testClass
 
     @BeforeClass
-    public static void setUpMocks() throws Exception {
+    static void setUpMocks() throws Exception {
         //Setup plugins and default configuration folders
-        LibrariesFactory.initializeFactory(true);
-        LibrariesFactory.getInstance().loadLibraries(LibrariesFactory.buildupPluginQueue(LibrariesFactoryTest.callLoadMapOfAvailablePlugins(), "DefaultPlugin").values() as List);
+        LibrariesFactory.initializeFactory(true)
+        LibrariesFactory.getInstance().loadLibraries(LibrariesFactory.buildupPluginQueue(LibrariesFactoryTest.callLoadMapOfAvailablePlugins(), "DefaultPlugin").values() as List)
         ConfigurationFactory.initialize(LibrariesFactory.getInstance().getLoadedPlugins().collect { it -> it.getConfigurationDirectory() })
 
         final Configuration mockupConfig = new Configuration(new InformationalConfigurationContent(null, Configuration.ConfigurationType.OTHER, "default", "", "", null, "", ResourceSetSize.l, null, null, null, null), ConfigurationFactory.getInstance().getConfiguration("default")) {
             @Override
             File getSourceToolPath(String tool) {
                 if (tool == "wrapinScript")
-                    return super.getSourceToolPath(tool);
+                    return super.getSourceToolPath(tool)
                 return new File("/tmp/RoddyTests/RoddyTestScript_ExecutionServiceTest.sh")
             }
-        };
+        }
 
-        mockedContext = MockupExecutionContextBuilder.createSimpleContext(FilenamePatternTest, mockupConfig);
+        mockedContext = MockupExecutionContextBuilder.createSimpleContext(FilenamePatternTest, mockupConfig)
 
-        testClass = LibrariesFactory.getInstance().loadRealOrSyntheticClass("FilenamePatternTest_testFilenamePatternWithSelectionByToolID", BaseFile.class as Class<FileObject>);
+        testClass = LibrariesFactory.getInstance().loadRealOrSyntheticClass("FilenamePatternTest_testFilenamePatternWithSelectionByToolID", BaseFile.class as Class<FileObject>)
 
-        ToolEntry toolEntry = new ToolEntry("RoddyTests", "RoddyTests", "RoddyTestScript_ExecutionServiceTest.sh");
+        ToolEntry toolEntry = new ToolEntry("RoddyTests", "RoddyTests", "RoddyTestScript_ExecutionServiceTest.sh")
         toolEntry.getOutputParameters(mockupConfig).add(new ToolFileParameter(testClass, null, "TEST", new ToolFileParameterCheckCondition(true)))
 
-        mockupConfig.getTools().add(toolEntry);
+        mockupConfig.getTools().add(toolEntry)
     }
 
     @After
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
 
     }
 
     @Test
-    public void testFilenamePatternWithSelectionByToolID() {
-        FilenamePattern fp = new OnToolFilenamePattern(testClass, "RoddyTests", "/tmp/RoddyTests/testFileResult.sh", "default");
-        BaseFile.ConstructionHelperForGenericCreation helper = new BaseFile.ConstructionHelperForGenericCreation(mockedContext, mockedContext.getConfiguration().getTools().getValue("RoddyTests"), "RoddyTests", null, null, new TestFileStageSettings(), null);
-        String filename = fp.apply((BaseFile) testClass.newInstance(helper));
-        assert filename == "/tmp/RoddyTests/testFileResult.sh";
+    void testFilenamePatternWithSelectionByToolID() {
+        FilenamePattern fp = new OnToolFilenamePattern(testClass, "RoddyTests", "/tmp/RoddyTests/testFileResult.sh", "default")
+        BaseFile.ConstructionHelperForGenericCreation helper = new BaseFile.ConstructionHelperForGenericCreation(mockedContext, mockedContext.getConfiguration().getTools().getValue("RoddyTests"), "RoddyTests", null, null, new TestFileStageSettings(), null)
+        String filename = fp.apply((BaseFile) testClass.newInstance(helper))
+        assert filename == "/tmp/RoddyTests/testFileResult.sh"
     }
 
     @Test
-    public void testFilenamePatternWithDerivedParentClass() {
+    void testFilenamePatternWithDerivedParentClass() {
         assert false
     }
 
     @Test
-    public void testFilenamePatternWithSelectionByMethod() {
+    void testFilenamePatternWithSelectionByMethod() {
         assert false
     }
 
     @Test
-    public void testFilenamePatternWithFileStage() {
+    void testFilenamePatternWithFileStage() {
         assert false
     }
 
@@ -108,7 +108,7 @@ public class FilenamePatternTest {
     }
 
     @Test
-    public void testJobCreationWithFileUsingToolIDForNamePattern() {
+    void testJobCreationWithFileUsingToolIDForNamePattern() {
         JobManager.initializeFactory(new JobManager() {
             @Override
             void createUpdateDaemonThread(int interval) {
@@ -206,21 +206,80 @@ public class FilenamePatternTest {
             }
         })
 
-        FilenamePattern fp = new OnToolFilenamePattern(testClass, "RoddyTests", "/tmp/RoddyTests/testFileResult.sh", "default");
-        mockedContext.getConfiguration().getFilenamePatterns().add(fp);
-        BaseFile sourceFile = BaseFile.constructSourceFile(GenericFile, new File("/tmp/RoddyTests/output/abcfile"), mockedContext);
-        BaseFile result = (BaseFile) GenericMethod.callGenericTool("RoddyTests", sourceFile);
+        FilenamePattern fp = new OnToolFilenamePattern(testClass, "RoddyTests", "/tmp/RoddyTests/testFileResult.sh", "default")
+        mockedContext.getConfiguration().getFilenamePatterns().add(fp)
+        BaseFile sourceFile = BaseFile.constructSourceFile(GenericFile, new File("/tmp/RoddyTests/output/abcfile"), mockedContext)
+        BaseFile result = (BaseFile) GenericMethod.callGenericTool("RoddyTests", sourceFile)
         assert result != null
-        assert result.class == testClass;
+        assert result.class == testClass
     }
 
     @Test
-    public void testExtractCommand() {
+    void testExtractCommand() {
         assert false
     }
 
     @Test
-    public void testExtractCommands() {
+    void testExtractCommands() {
         assert false
+    }
+
+    @Test
+    void testFillFileGroupIndex() {
+        String src = 'abc_${fgindex}_def'
+        def parentFile = new GenericFile(new BaseFile.ConstructionHelperForManualCreation(mockedContext, null, null, null, null, null, null));
+        def file = new GenericFile(new BaseFile.ConstructionHelperForManualCreation(parentFile, null, null, null, null, null, "1", null, null));
+        file.hasIndexInFileGroup()
+        assert createFilenamePattern().fillFileGroupIndex(src, file) == 'abc_1_def'
+    }
+
+    @Test
+    void testFillDirectories() {
+        assert false
+    }
+
+    @Test
+    void testFillConfigurationVariable() {
+        String srcFull = 'something_${avalue}_${cvalue,name="anothervalue"}_${cvalue,name="unknown",default="bebe"}'
+        ExecutionContext context = createMockupContext()
+        FilenamePattern fpattern = createFilenamePattern()
+        assert fpattern.fillConfigurationVariables(srcFull, context) == 'something_abc_abc_bebe'
+    }
+
+    @Test
+    void testFillWithUnsetVariables() {
+        String srcFull = 'something_${avalue}_${cvalue,name="anothervalue"}_${cvalue,name="unknown"}'
+        ExecutionContext context = createMockupContext()
+        FilenamePattern fpattern = createFilenamePattern()
+        assert fpattern.fillConfigurationVariables(srcFull, context) == 'something_abc_abc_${cvalue}'
+    }
+
+    @Test
+    void testWithDataSetID() {
+        String srcFull = 'something_${avalue}_${cvalue,name="unknown"}_${pid}_${fileStageID[0]}'
+        ExecutionContext context = createMockupContext()
+        FilenamePattern fpattern = createFilenamePattern()
+        assert fpattern.fillConfigurationVariables(srcFull, context) == 'something_abc_${cvalue}_${pid}_${fileStageID[0]}'
+    }
+
+    private FilenamePattern createFilenamePattern() {
+        String srcFull
+        def fpattern = new FilenamePattern(LibrariesFactory.getInstance().loadRealOrSyntheticClass("FPTTestClass", "BaseFile"), srcFull, "default") {
+
+            @Override
+            String getID() { return null }
+
+            @Override
+            FilenamePatternDependency getFilenamePatternDependency() { return null }
+        }
+        fpattern
+    }
+
+    private ExecutionContext createMockupContext() {
+        Configuration cfg = new Configuration(null);
+        cfg.configurationValues << new ConfigurationValue(cfg, "avalue", "abc")
+        cfg.configurationValues << new ConfigurationValue(cfg, "anothervalue", "abc")
+        def context = MockupExecutionContextBuilder.createSimpleContext(getClass(), cfg)
+        context
     }
 }

--- a/RoddyCore/test/de/dkfz/roddy/core/RuntimeServiceTest.java
+++ b/RoddyCore/test/de/dkfz/roddy/core/RuntimeServiceTest.java
@@ -8,6 +8,7 @@ package de.dkfz.roddy.core;
 
 import de.dkfz.roddy.config.*;
 import de.dkfz.roddy.knowledge.files.BaseFile;
+import groovy.transform.CompileStatic;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -16,6 +17,7 @@ import java.util.Map;
 /**
  * Created by heinold on 09.11.15.
  */
+@CompileStatic
 public class RuntimeServiceTest {
 
     private static RuntimeService mockedService;


### PR DESCRIPTION
The wrong parameter name was used for file group outputs. The correct
one is now set.

Some code was moved in FilenamePattern and Job to make the code more
readable.

Extracted methods in FilenamePattern to create better readable code
(Especially the apply method)

Created some tests to ensure that nothing breaks and to document
features.

Added the possibility for short variable syntax in filename patterns:
Both refer to the same variable: "${cvalue,name="test"}_${test}"
The short syntax does not allow default values. It is either set or
left like it is.