### PR TITLE
Remove proven FToggles, Add toggle for BashConverter

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.java
+++ b/RoddyCore/src/de/dkfz/roddy/AvailableFeatureToggles.java
@@ -12,16 +12,9 @@ package de.dkfz.roddy;
  */
 public enum AvailableFeatureToggles {
 
-    XMLValidation(true),
     ForbidSubmissionOnRunning(false),
     BreakSubmissionOnError(false),
-    RollbackOnSubmissionOnError(false),
-    // Modify bash arrays and pass them with a different separator. (comma instead of whitespace)
-    ModifiedVariablePassing(true),
-    QuoteSomeScalarConfigValues(true),
-    UseOldDataSetIDExtraction(true),
-    AutoFilenames(false),
-    UnzipZippedPlugins(false);
+    UseDeclareFunctionalityForBashConverter(true);
 
     public final boolean defaultValue;
 

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
@@ -209,7 +209,7 @@ class BashConverter extends ConfigurationConverter {
         StringBuilder text = new StringBuilder();
         String declareVar = ""
         String declareInt = ""
-        if (Roddy.getFeatureToggleValue(AvailableFeatureToggles.UseDeclareFunctionalityForBashConverter)) {
+        if (context.getFeatureToggleStatus(AvailableFeatureToggles.UseDeclareFunctionalityForBashConverter)) {
             declareVar = "declare -x   "
             declareInt = "declare -x -i"
         }

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
@@ -207,21 +207,28 @@ class BashConverter extends ConfigurationConverter {
 
     StringBuilder convertConfigurationValue(ConfigurationValue cv, ExecutionContext context, Boolean quoteSomeScalarConfigValues) {
         StringBuilder text = new StringBuilder();
+        String declareVar = ""
+        String declareInt = ""
+        if (Roddy.getFeatureToggleValue(AvailableFeatureToggles.UseDeclareFunctionalityForBashConverter)) {
+            declareVar = "declare -x   "
+            declareInt = "declare -x -i"
+        }
         if (cv.toString().startsWith("#COMMENT")) {
             text << cv.toString();
         } else {
-            String tmp;
-            if (cv.type && cv.type.toLowerCase() == "basharray") {
+            String tmp
+
+                if (cv.type && cv.type.toLowerCase() == "basharray") {
                 // Check, if it is already quoted.
                 // If so, take the existing quotes.
                 if (isQuoted(cv.value))
-                    return new StringBuilder("declare -x    ${cv.id}=${cv.toString()}".toString());
+                    return new StringBuilder("${declareVar} ${cv.id}=${cv.toString()}".toString());
                 // If not, quote
-                return new StringBuilder("declare -x    ${cv.id}=\"${cv.toString()}\"".toString());
+                return new StringBuilder("${declareVar} ${cv.id}=\"${cv.toString()}\"".toString());
             } else if (cv.type && cv.type.toLowerCase() == "integer") {
-                return new StringBuilder("declare -x -i ${cv.id}=${cv.toString()}".toString());
+                return new StringBuilder("${declareInt} ${cv.id}=${cv.toString()}".toString());
             } else if (cv.type && ["double", "float"].contains(cv.type.toLowerCase())) {
-                return new StringBuilder("declare -x    ${cv.id}=${cv.toString()}".toString());
+                return new StringBuilder("${declareVar} ${cv.id}=${cv.toString()}".toString());
             } else if (cv.type && cv.type.toLowerCase() == "path") {
                 tmp = "${cv.toFile(context)}".toString();
             } else {
@@ -233,7 +240,7 @@ class BashConverter extends ConfigurationConverter {
                     tmp = "${cv.toString()}".toString();
                 }
             }
-            text << "declare -x    ${cv.id}=";
+            text << "${declareVar} ${cv.id}=";
             //TODO Important, this is a serious hack! It must be removed soon
             if (tmp.startsWith("bundledFiles/")) {
                 text << Roddy.getApplicationDirectory().getAbsolutePath() << FileSystemAccessProvider.getInstance().getPathSeparator();
@@ -246,7 +253,7 @@ class BashConverter extends ConfigurationConverter {
     @Override
     @CompileStatic
     StringBuilder convertConfigurationValue(ConfigurationValue cv, ExecutionContext context) {
-        convertConfigurationValue(cv, context, Roddy.getFeatureToggleValue(AvailableFeatureToggles.QuoteSomeScalarConfigValues))
+        convertConfigurationValue(cv, context, true)
     }
 
     public Configuration loadShellScript(String configurationFile) {

--- a/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ExecutionContext.groovy
@@ -6,9 +6,12 @@
 
 package de.dkfz.roddy.core
 
+import de.dkfz.roddy.AvailableFeatureToggles
 import de.dkfz.roddy.Constants
+import de.dkfz.roddy.Roddy
 import de.dkfz.roddy.config.Configuration
 import de.dkfz.roddy.config.ConfigurationConstants
+import de.dkfz.roddy.config.ConfigurationValue
 import de.dkfz.roddy.config.RecursiveOverridableMapContainerForConfigurationValues
 import de.dkfz.roddy.config.ToolEntry
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
@@ -295,6 +298,13 @@ class ExecutionContext {
 
     Configuration getFileConfiguration(BaseFile baseFile) {
 
+    }
+
+    boolean getFeatureToggleStatus(AvailableFeatureToggles toggle) {
+        def cvalues = getConfiguration().getConfigurationValues()
+        if(cvalues.hasValue(toggle.name()))
+            return cvalues.get(toggle.name()).toBoolean()
+        return Roddy.getFeatureToggleValue(toggle)
     }
 
     RecursiveOverridableMapContainerForConfigurationValues getConfigurationValues() {

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectFactory.groovy
@@ -219,8 +219,7 @@ public class ProjectFactory {
 
         ProjectConfiguration projectConfiguration = fac.getProjectConfiguration(projectID);
         InformationalConfigurationContent iccAnalysis = ((AnalysisConfigurationProxy) projectConfiguration.getAnalysis(analysisID)).informationalConfigurationContent;
-        if (Roddy.getFeatureToggleValue(AvailableFeatureToggles.XMLValidation))
-            XSDValidator.validateTree(iccAnalysis);
+        XSDValidator.validateTree(iccAnalysis);
         Project project = loadConfiguration(projectConfiguration);
 
         AnalysisConfiguration ac = projectConfiguration.getAnalysis(analysisID);
@@ -333,8 +332,7 @@ public class ProjectFactory {
         }
 
         //Validate the project icc
-        if (Roddy.getFeatureToggleValue(AvailableFeatureToggles.XMLValidation))
-            XSDValidator.validateTree(iccProject);
+        XSDValidator.validateTree(iccProject);
         return iccProject;
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/BaseFile.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/BaseFile.groovy
@@ -541,17 +541,6 @@ abstract class BaseFile<FS extends FileStageSettings> extends FileObject {
                 }
             }
         } catch (RuntimeException ex) {
-            if (Roddy.getFeatureToggleValue(AvailableFeatureToggles.AutoFilenames)) {
-                // In case that we did not find a pattern and therefore could not create a filename, we will now apply an automatic filename.
-
-                // This might work for GenericMethod calls! But surely not for other ones...
-
-                // The problem is, that we need to get some sort of jobname and / or an internal job id. But! Jobs normally get created after the files.
-                // Then files get assigned to the job on its creation. However, GenericMethod calls, at least have some info about the running script.
-                // Manual calls might miss this information and it will possibly get ugly to extract info on this.
-            } else {
-                throw ex;
-            }
         } finally {
             return patternResult;
         }

--- a/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
@@ -464,18 +464,6 @@ public class LibrariesFactory extends Initializable {
             File prodEntry = null;
             File zipFile = null;
 
-            if (pEntry.getName().endsWith(".zip")) {
-                // Zip files are handled differently and cannot be checked for contents!
-                zipFile = pEntry;
-                if (Roddy.getFeatureToggleValue(AvailableFeatureToggles.UnzipZippedPlugins)) {
-                    if (!new File(zipFile.getAbsolutePath()[0..-5]).exists()) {
-                        if (!helpMode) logger.postAlwaysInfo("Unzipping zipped plugin (this is done unchecked and unlocked, processes could interfere with each other!)")
-                        (new RoddyIOHelperMethods.NativeLinuxZipCompressor()).decompress(zipFile, null, zipFile.getParentFile());
-                    }
-                }
-                continue;
-            }
-
             if (zipFile != null) { // Only "releases" / packages have a zip file and need not to be dissected further.
                 continue;
             }


### PR DESCRIPTION
Some workflows lack the possibility to use the safer declare -x Bash
syntax. The new feature toggle UseDeclareFunctionalityForBashConverter
defaults to true and can be disabled on the command line with
--disabletoggles=UseDeclareFunctionalityForBashConverter
or in the feature toggle ini file.