### PR TITLE
Clean up startup messages, correct cli toggle input

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
@@ -505,13 +505,13 @@ public class RoddyCLIClient {
             def numberOfJobs = collectedJobs.size()
 
             if (numberOfJobs > 0) {
-                sb << "#FWHITE##BGBLUE#Information about run test for dataset: " << ec.getDataSet().getId() << "#CLEAR#" << separator;
-                sb << "  Input directory     : ${ec.getInputDirectory()}" << separator;
-                sb << "  Output directory    : ${ec.getOutputDirectory()}" << separator;
-                sb << "  Execution directory : ${ec.getExecutionDirectory()}" << separator;
+                sb << "\n#FWHITE##BGBLUE#Information about run test for dataset: " << ec.getDataSet().getId() << "#CLEAR#" << separator;
+                sb << "  #FWHITE#Input directory#CLEAR#     : ${ec.getInputDirectory()}" << separator;
+                sb << "  #FWHITE#Output directory#CLEAR#    : ${ec.getOutputDirectory()}" << separator;
+                sb << "  #FWHITE#Execution directory#CLEAR# : ${ec.getExecutionDirectory()}" << separator;
                 sb << "  #FWHITE#List of jobs (${numberOfJobs}):#CLEAR#" << separator;
             } else {
-                sb << "There were no executed jobs for dataset " << ec.getDataSet().getId() << separator;
+                sb << "#FRED#There were no executed jobs for dataset " << ec.getDataSet().getId() << "#CLEAR#" << separator;
             }
 
             for (Job job : collectedJobs) {
@@ -541,7 +541,7 @@ public class RoddyCLIClient {
                         parm = parm.replace("(", "(\n" + " ".padRight(38));
                         parm = parm.replace(")", "\n" + " ".padRight(34) + ")");
                     }
-                    sb << "      #FYELLOW#${_k.padRight(26)}: ${parm}" << "#CLEAR#" << separator;
+                    sb << "      ${_k.padRight(26)}: ${parm}"  << separator;
                 }
             }
 

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.java
@@ -400,7 +400,7 @@ public class Analysis {
             }
 
             // Print out context errors.
-            if (context.getErrors().size() > 0) {
+            if (context.getExecutionContextLevel() != ExecutionContextLevel.QUERY_STATUS && context.getErrors().size() > 0) {
                 StringBuilder messages = new StringBuilder();
                 boolean warningsOnly = true;
                 for (ExecutionContextError executionContextError : context.getErrors()) {

--- a/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
@@ -200,7 +200,7 @@ public class LibrariesFactory extends Initializable {
             if (listOfClasses.size() == 1) {
                 return groovyClassLoader.loadClass(listOfClasses[0]);
             }
-            logger.severe("No class found for ${name}")
+            logger.postSometimesInfo("No class found for ${name}")
             return null;
         }
     }
@@ -210,7 +210,7 @@ public class LibrariesFactory extends Initializable {
         if (_cls == null) {
             _cls = generateSyntheticFileClassWithParentClass(classOfFileObject, baseClassOfFileObject, LibrariesFactory.getGroovyClassLoader())
             LibrariesFactory.getInstance().getSynthetic().addClass(_cls);
-            logger.severe("Class ${classOfFileObject} could not be found, created synthetic class ${_cls.name}.");
+            logger.postSometimesInfo("Class ${classOfFileObject} could not be found, created synthetic class ${_cls.name}.");
         }
         return _cls
     }


### PR DESCRIPTION
It is not only about colours. But the testrun/rerun where cleaned up.

Also toggle values are now parsed in a correct way. If a toggle value
does not exist, an error is shown and a list of available toggles is
printed.

If the ini file is not found, Roddy will not start!