### PR TITLE
Cleaned load errors, Fix cyclic depencies

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationFactory.groovy
@@ -34,6 +34,7 @@ import de.dkfz.roddy.tools.TimeUnit
 import de.dkfz.roddy.tools.RoddyIOHelperMethods
 import groovy.transform.TypeCheckingMode
 import groovy.util.slurpersupport.*
+import jdk.internal.org.xml.sax.SAXParseException
 import org.apache.commons.io.filefilter.WildcardFileFilter
 
 import java.lang.reflect.*
@@ -161,11 +162,14 @@ public class ConfigurationFactory {
 
                 } else {
                     if (availableConfigurations[icc.name].file != icc.file)
-                        throw new RuntimeException("Configuration with name ${icc.name} already exists! Names must be unique.")
+                        throw new ProjectLoaderException("Configuration with name ${icc.name} already exists! Names must be unique.")
                 }
+            } catch (org.xml.sax.SAXParseException ex) {
+                throw new ProjectLoaderException("The validation of a configuration file ${it.absolutePath} failed.")
             } catch (Exception ex) {
-                logger.severe("File ${it.absolutePath} cannot be loaded! Error in config file! ${ex.toString()}");
-                logger.severe(RoddyIOHelperMethods.getStackTraceAsString(ex));
+                logger.severe("An unknown exception occured during the atempt to load a configuration file:\n\t${it.absolutePath} cannot be loaded.\n\t${ex.toString()}")
+                logger.sometimes(RoddyIOHelperMethods.getStackTraceAsString(ex));
+                throw ex
             }
         }
     }

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.java
@@ -273,6 +273,11 @@ public class ConfigurationValue implements RecursiveOverridableMapContainer.Iden
         if (configuration != null) {
             List<String> valueIDs = getIDsForParentValues();
             for (String vName : valueIDs) {
+                if (temp.contains("${" + vName) || temp.contains("${cvalue,name=\"" + vName)){
+                    RuntimeException exc = new RuntimeException("Cyclic dependency found for cvalue '" + vName + "'");
+                    configuration.addLoadError(new ConfigurationLoadError(configuration, "cValues", "Cyclic dependency found for cvalue '" + vName + "'", exc));
+                    throw exc;
+                }
                 if (configuration.getConfigurationValues().hasValue(vName))
                     temp = temp.replace("${" + vName + '}', configuration.getConfigurationValues().get(vName).toString());
             }

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
@@ -15,6 +15,7 @@ import de.dkfz.roddy.execution.io.MetadataTableFactory
 import de.dkfz.roddy.plugins.LibrariesFactory
 import de.dkfz.roddy.plugins.PluginInfo
 import de.dkfz.roddy.plugins.PluginInfoMap
+import jdk.internal.org.xml.sax.SAXParseException
 
 import java.lang.reflect.InvocationTargetException
 

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTest.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTest.xml
@@ -14,11 +14,14 @@
         <cvalue name='analysisMethodNameOnOutput' value='testAnalysis' type='string'/>
 
         <cvalue name="testAOutputDirectory" value="testfiles" type="path"/>
+        <!--<cvalue name="valuec" value="${valuea}"/>-->
+        <!--<cvalue name="valuea" value="${valueb}"/>-->
+        <!--<cvalue name="valueb" value="${valuea}"/>-->
         <cvalue name="testOutputDirectory" value="${outputAnalysisBaseDirectory}/testfiles" type="path"/>
-        <cvalue name="testInnerOutputDirectory" value="${testOutputDirectory}/testfilesw2" />
+        <cvalue name="testInnerOutputDirectory" value="${testOutputDirectory}/testfilesw2"/>
     </configurationvalues>
     <processingTools>
-        <tool name="cleanupScript" value="cleanupScript.sh" basepath="roddyTests" >
+        <tool name="cleanupScript" value="cleanupScript.sh" basepath="roddyTests">
             <resourcesets>
                 <rset size="l" memory="0.1" cores="1" nodes="1" walltime="1"/>
             </resourcesets>


### PR DESCRIPTION
Cyclic dependencies are now detected. The mechanism is somewhat crude
but should work.

Cleaned up the error throwing mechanism for configuration loader errors.
SaxParseExceptions will be catched and converted to a
ProjectLoaderException thus resulting in less stack trace printouts.
Unknown errors will still be printed fully.