### PR TITLE
Add custom exception, add better logging for plugin loading

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
@@ -15,6 +15,7 @@ import de.dkfz.roddy.execution.io.MetadataTableFactory
 import de.dkfz.roddy.plugins.LibrariesFactory
 import de.dkfz.roddy.plugins.PluginInfo
 import de.dkfz.roddy.plugins.PluginInfoMap
+import de.dkfz.roddy.plugins.PluginLoaderException
 
 import java.lang.reflect.InvocationTargetException
 
@@ -146,8 +147,11 @@ class ProjectLoader {
             MetadataTableFactory.getTable(analysis);
             return analysis;
         } catch (ProjectLoaderException ex) {
-            logger.severe(ex.message);
+            logger.severe(ex.message)
             return null;
+        } catch (PluginLoaderException ex) {
+            logger.severe(ex.message)
+            return null
         }
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/LibrariesFactory.groovy
@@ -302,11 +302,11 @@ public class LibrariesFactory extends Initializable {
         for (File pBaseDirectory : pluginDirectories) {
             logger.postSometimesInfo("Parsing plugins folder: ${pBaseDirectory}");
             if (!pBaseDirectory.exists()) {
-                logger.warning("The plugins directory $pBaseDirectory does not exist.")
+                logger.severe("The plugins directory $pBaseDirectory does not exist.")
                 continue;
             }
             if (!pBaseDirectory.canRead()) {
-                logger.warning("The plugins directory $pBaseDirectory is not readable.")
+                logger.severe("The plugins directory $pBaseDirectory is not readable.")
             }
 
             File[] directoryList = pBaseDirectory.listFiles().sort() as File[];

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfoMap.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginInfoMap.groovy
@@ -6,6 +6,7 @@
 
 package de.dkfz.roddy.plugins
 
+import de.dkfz.roddy.Roddy
 import de.dkfz.roddy.StringConstants
 
 /**
@@ -72,10 +73,12 @@ class PluginInfoMap {
      */
     public PluginInfo getPluginInfo(String pluginID, String version) {
         if (!version) version = "current";
+        String additionalMessage = "\n#FRED#Please check, if you have proper access to all plugin directories. Plugins are in the following directories:\n\t#CLEAR#"
+        additionalMessage += Roddy.getPluginDirectories().collect { it.getAbsolutePath() }.join("\n\t")
         if (!mapOfPlugins[pluginID]) //Can this case occur?
-            throw new RuntimeException("Plugin ${pluginID} is not available, available are:\n\t" + mapOfPlugins.keySet().join("\t\n"))
+            throw new PluginLoaderException("Plugin ${pluginID} is not available, available are:\n\t" + mapOfPlugins.keySet().join("\n\t") + additionalMessage)
         if (!mapOfPlugins[pluginID][version])
-            throw new RuntimeException("Version ${version} of plugin ${pluginID} is not available, know versions are:\n\t" + mapOfPlugins[pluginID].keySet().join("\t\n"))
+            throw new PluginLoaderException("Version ${version} of plugin ${pluginID} is not available, know versions are:\n\t" + mapOfPlugins[pluginID].keySet().join("\t\n") + additionalMessage)
         return mapOfPlugins[pluginID][version]
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/plugins/PluginLoaderException.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/plugins/PluginLoaderException.groovy
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2017 eilslabs.
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
+
+package de.dkfz.roddy.plugins
+
+/**
+ * Created by heinold on 27.04.17.
+ */
+class PluginLoaderException extends Throwable {
+    PluginLoaderException(String s) {
+        super(s)
+    }
+}


### PR DESCRIPTION
Add the PluginLoaderException class which can be used for errors in
LibrariesFactory.

Catch the new exception and prevent a stack trace. Also print out a lot
more details, what might be wrong and how to fix it.