### PR TITLE
Fix job abortion on workflow errors

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -501,6 +501,7 @@ public class Roddy {
             return true;
         } catch (Exception ex) {
             logger.severe("initializeServices failed with an unhandled error. The step in which the error occurred was: " + currentStep + "\nSee the following stacktrace for more details.", ex);
+            logger.severe(RoddyIOHelperMethods.getStackTraceAsString(ex));
             return false;
         }
     }

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.java
@@ -389,8 +389,10 @@ public class Analysis {
                         context.execute();
                         finallyStartJobsOfContext(context);
                     }
-                } finally {
+                } catch(Exception ex) {
+                    // (Maybe) abort jobs in strict mode
                     abortStartedJobsOfContext(context);
+                } finally {
 
                     if (context.getExecutionContextLevel() == ExecutionContextLevel.QUERY_STATUS) { //Clean up
                         //Query file validity of all files
@@ -496,6 +498,9 @@ public class Analysis {
             } catch (Exception ex) {
                 logger.severe("Could not successfully abort jobs.", ex);
             }
+        } else {
+            logger.severe("An workflow error occurred. However, strict mode is disabled and/or RollbackOnWorkflowError is disabled and therefore, all submitted jobs will be left running." +
+                    "\n\tYou might consider to enable Roddy strict mode by setting the feature toggles 'StrictMode' and 'RollbackOnWorkflowError'.");
         }
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/core/Analysis.java
+++ b/RoddyCore/src/de/dkfz/roddy/core/Analysis.java
@@ -389,9 +389,9 @@ public class Analysis {
                         context.execute();
                         finallyStartJobsOfContext(context);
                     }
-                } catch(Exception ex) {
+                } catch (Exception ex) {
                     // (Maybe) abort jobs in strict mode
-                    abortStartedJobsOfContext(context);
+                    maybeAbortStartedJobsOfContext(context);
                 } finally {
 
                     if (context.getExecutionContextLevel() == ExecutionContextLevel.QUERY_STATUS) { //Clean up
@@ -490,16 +490,16 @@ public class Analysis {
      *
      * @param context
      */
-    private void abortStartedJobsOfContext(ExecutionContext context) {
+    private void maybeAbortStartedJobsOfContext(ExecutionContext context) {
         if (Roddy.isStrictModeEnabled() && context.getFeatureToggleStatus(AvailableFeatureToggles.RollbackOnWorkflowError)) {
             try {
-                logger.severe("An workflow error occurred, try to rollback / abort submitted jobs.");
+                logger.severe("A workflow error occurred, try to rollback / abort submitted jobs.");
                 Roddy.getJobManager().queryJobAbortion(context.jobsForProcess);
             } catch (Exception ex) {
                 logger.severe("Could not successfully abort jobs.", ex);
             }
         } else {
-            logger.severe("An workflow error occurred. However, strict mode is disabled and/or RollbackOnWorkflowError is disabled and therefore, all submitted jobs will be left running." +
+            logger.severe("A workflow error occurred. However, strict mode is disabled and/or RollbackOnWorkflowError is disabled and therefore, all submitted jobs will be left running." +
                     "\n\tYou might consider to enable Roddy strict mode by setting the feature toggles 'StrictMode' and 'RollbackOnWorkflowError'.");
         }
     }


### PR DESCRIPTION
The abort command will now only be called, when an exception occurs.

Another logger message will be shown, stating what you can do to enable
strict mode.