### PR TITLE
Roled out the ConfigurationError exception and other exception change…

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfigurationProxy.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/AnalysisConfigurationProxy.java
@@ -259,17 +259,17 @@ public class AnalysisConfigurationProxy extends AnalysisConfiguration {
     }
 
     @Override
-    public File getSourceToolPath(String tool) {
+    public File getSourceToolPath(String tool) throws ConfigurationError {
         return checkAnalysisConfig().getSourceToolPath(tool);
     }
 
     @Override
-    public File getProcessingToolPath(ExecutionContext context, String tool) {
+    public File getProcessingToolPath(ExecutionContext context, String tool) throws ConfigurationError {
         return checkAnalysisConfig().getProcessingToolPath(context, tool);
     }
 
     @Override
-    public String getProcessingToolMD5(String tool) {
+    public String getProcessingToolMD5(String tool) throws ConfigurationError {
         return checkAnalysisConfig().getProcessingToolMD5(tool);
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationError.groovy
@@ -4,7 +4,7 @@
  * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
  */
 
-package de.dkfz.roddy.config.loader
+package de.dkfz.roddy.config
 
 import de.dkfz.roddy.config.Configuration
 import groovy.transform.CompileStatic
@@ -27,7 +27,11 @@ class ConfigurationError extends Exception {
         this.exception = exception
     }
 
-    ConfigurationError(String description, Configuration configuration) {
-        this(description, configuration, null, null)
+    ConfigurationError(String description, Configuration configuration, Exception ex = null) {
+        this(description, configuration, null, ex)
+    }
+
+    ConfigurationError(String description, String id, Exception ex = null) {
+        this(description, null, id, ex)
     }
 }

--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValue.java
@@ -316,16 +316,21 @@ public class ConfigurationValue implements RecursiveOverridableMapContainer.Iden
     }
 
     public EnumerationValue getEnumerationValueType() {
-        Enumeration enumeration = null;
-        if (getConfiguration().getEnumerations().hasValue("cvalueType"))
+        return getEnumerationValueType(null);
+    }
+
+    public EnumerationValue getEnumerationValueType(EnumerationValue defaultType) {
+        Enumeration enumeration;
+        try {
             enumeration = getConfiguration().getEnumerations().getValue("cvalueType");
-        String _ev = getType();
-        if (_ev == null || _ev.trim().equals(""))
-            _ev = "string";
-        if (enumeration == null)
-            return null;
-        EnumerationValue ev = enumeration.getValue(_ev);
-        return ev;
+            String _ev = getType();
+            if (_ev == null || _ev.trim().equals(""))
+                _ev = "string";
+            EnumerationValue ev = enumeration.getValue(_ev);
+            return ev;
+        } catch (ConfigurationError e) {
+            return defaultType;
+        }
     }
 
     public boolean isInvalid() {

--- a/RoddyCore/src/de/dkfz/roddy/config/Enumeration.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/Enumeration.groovy
@@ -43,8 +43,8 @@ public class Enumeration implements RecursiveOverridableMapContainer.Identifiabl
 
     EnumerationValue getValue(String ev) {
         if (values.containsKey(ev))
-            return values[ev];
-        throw new RuntimeException("Type ${ev} is not known in enumeration ${name}");
+            return values[ev]
+        throw new NoSuchElementException("Type ${ev} is not known in enumeration ${name}")
     }
 
     @Override

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainer.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainer.java
@@ -6,6 +6,7 @@
 
 package de.dkfz.roddy.config;
 
+import de.dkfz.roddy.config.ConfigurationError;
 import de.dkfz.roddy.tools.RoddyConversionHelperMethods;
 
 import java.util.LinkedHashMap;
@@ -78,7 +79,7 @@ public class RecursiveOverridableMapContainer<K, V extends RecursiveOverridableM
         return new LinkedList<>(getAllValues().values());
     }
 
-    public List<V> getInheritanceList(String valueID) {
+    public List<V> getInheritanceList(String valueID) throws ConfigurationError {
         List<V> allValues = new LinkedList<>();
 
         if (getMap().containsKey(valueID))
@@ -144,12 +145,12 @@ public class RecursiveOverridableMapContainer<K, V extends RecursiveOverridableM
     }
 
     /**
-     * @throws RuntimeException if a value is requested that does not exist.
+     * @throws ConfigurationError if a value is requested that does not exist.
      * @param id    Configuration value to return.
      */
-    public V getValue(String id) {
+    public V getValue(String id) throws ConfigurationError {
         if (!hasValue(id))
-            throw new RuntimeException("Value " + id + " could not be found in containers with id " + id);
+            throw new ConfigurationError("Value could not be found in containers", id);
         return _getValueUnchecked(id);
     }
 

--- a/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/RecursiveOverridableMapContainerForConfigurationValues.java
@@ -18,10 +18,10 @@ public class RecursiveOverridableMapContainerForConfigurationValues
     }
 
     public ConfigurationValue get(String id, String defaultValue) {
-        if (!hasValue(id)) {
-            return new ConfigurationValue(getContainerParent(), id, defaultValue);
-        } else {
+        try {
             return getValue(id);
+        } catch (ConfigurationError ex) {
+            return new ConfigurationValue(getContainerParent(), id, defaultValue);
         }
     }
 
@@ -54,7 +54,7 @@ public class RecursiveOverridableMapContainerForConfigurationValues
     }
 
     /** Get value or throw a RuntimeException, if the value does not exist. */
-    public ConfigurationValue getOrThrow(String id) {
+    public ConfigurationValue getOrThrow(String id) throws ConfigurationError {
         return getValue(id);
     }
 
@@ -67,7 +67,11 @@ public class RecursiveOverridableMapContainerForConfigurationValues
     }
 
     public boolean getBoolean(String id, boolean b) {
-        return hasValue(id) ? getValue(id).toBoolean() : b;
+        try {
+            return getValue(id).toBoolean();
+        } catch (ConfigurationError e) {
+            return b;
+        }
     }
 
     /**
@@ -81,7 +85,11 @@ public class RecursiveOverridableMapContainerForConfigurationValues
     }
 
     public String getString(String id, String s) {
-        return hasValue(id) ? getValue(id).toString() : s;
+        try {
+            return getValue(id).toString();
+        } catch (ConfigurationError e) {
+            return s;
+        }
     }
 
     /**

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoadError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationLoadError.groovy
@@ -7,6 +7,7 @@
 package de.dkfz.roddy.config.loader
 
 import de.dkfz.roddy.config.Configuration
+import de.dkfz.roddy.config.ConfigurationError
 import groovy.transform.CompileStatic
 
 /**

--- a/RoddyCore/src/de/dkfz/roddy/config/validation/ValidationError.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/validation/ValidationError.groovy
@@ -7,7 +7,7 @@
 package de.dkfz.roddy.config.validation
 
 import de.dkfz.roddy.config.Configuration
-import de.dkfz.roddy.config.loader.ConfigurationError
+import de.dkfz.roddy.config.ConfigurationError
 
 /**
  * Errors thrown during validation

--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
@@ -42,6 +42,11 @@ class Job extends BEJob<BEJob, BEJobResult> {
     public final ExecutionContext context
 
     /**
+     * The local tool path
+     */
+    private final File localToolPath
+
+    /**
      * The tool you want to call.
      */
     private final String toolID
@@ -143,7 +148,8 @@ class Job extends BEJob<BEJob, BEJobResult> {
         return pJobs
     }
 
-    Job(ExecutionContext context, String jobName, String toolID, String inlineScript, List<String> arrayIndices, Map<String, Object> inputParameters, List<BaseFile> parentFiles, List<BaseFile> filesToVerify) {
+    Job(ExecutionContext context, String jobName, String toolID, String inlineScript, List<String> arrayIndices, Map<String, Object> inputParameters,
+        List<BaseFile> parentFiles, List<BaseFile> filesToVerify) {
         super(new BEJobID()
                 , jobName
                 , context.getConfiguration().getProcessingToolPath(context, TOOLID_WRAPIN_SCRIPT)
@@ -153,6 +159,7 @@ class Job extends BEJob<BEJob, BEJobResult> {
                 , []
                 , [:]
                 , Roddy.getJobManager())
+        this.localToolPath = context.getConfiguration().getSourceToolPath(toolID)
         this.setLoggingDirectory(context.loggingDirectory)
         this.addParentJobs(reconcileParentJobInformation(collectParentJobsFromFiles(parentFiles), collectDependencyIDsFromFiles(parentFiles), jobManager))
         this.context = context
@@ -195,7 +202,7 @@ class Job extends BEJob<BEJob, BEJobResult> {
         return te.getResourceSet(context.configuration) ?: new EmptyResourceSet();
     }
 
-    static String getToolMD5(String toolID, ExecutionContext context) {
+    static String getToolMD5(String toolID, ExecutionContext context) throws ConfigurationError {
         toolID != null && toolID.trim().length() > 0 ? context.getConfiguration().getProcessingToolMD5(toolID) : null
     }
 
@@ -766,15 +773,8 @@ class Job extends BEJob<BEJob, BEJobResult> {
         return toolID
     }
 
-    File getToolPath() {
-        return getExecutionContext().getConfiguration().getProcessingToolPath(getExecutionContext(), toolID)
-    }
-
     File getLocalToolPath() {
-        return getExecutionContext().getConfiguration().getSourceToolPath(toolID)
+        return localToolPath
     }
 
-    String getToolMD5() {
-        return toolID == null ? "-" : getExecutionContext().getConfiguration().getProcessingToolMD5(toolID)
-    }
 }

--- a/RoddyCore/src/de/dkfz/roddy/knowledge/files/BaseFile.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/knowledge/files/BaseFile.groovy
@@ -8,7 +8,7 @@ package de.dkfz.roddy.knowledge.files
 
 import de.dkfz.roddy.config.*
 
-import de.dkfz.roddy.config.loader.ConfigurationError
+import de.dkfz.roddy.config.ConfigurationError
 import de.dkfz.roddy.core.ExecutionContext
 import de.dkfz.roddy.core.ExecutionContextLevel
 import de.dkfz.roddy.core.Workflow


### PR DESCRIPTION
…s. Issue #83.

* Change from unchecked RuntimeException to ConfigurationError required `throws` annotation on some methods.
* Some of the hasValue()-based branching logic was substituted by try-catch blocks to simplify the logic while accounting for the checked exception errors.
* ConfigurationError was moved up one package.