### PR TITLE
Allow Roddy to skip full job manager init for most start modes

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModeScopes.java
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModeScopes.java
@@ -10,7 +10,7 @@ package de.dkfz.roddy.client;
  * Created by michael on 31.03.15.
  */
 @groovy.transform.CompileStatic
-public class RoddyStartupModeScopes {
+public enum RoddyStartupModeScopes {
 
     /**
      * Use this scope to leave options for command line processing.
@@ -19,16 +19,30 @@ public class RoddyStartupModeScopes {
      * This is useful, if things can be handled in an easier way with scripts,
      * like i.e. file operations
      */
-    public static final int SCOPE_CLI = 0x00;
+    SCOPE_CLI,
 
     /**
      * This scope is for startup modes where only a reduced init is necessary.
      */
-    public static final int SCOPE_REDUCED = 0x10;
+    SCOPE_REDUCED,
 
     /**
-     * This scope is for modes with a full init.
+     * This scope is for modes with a full init. The job manager however will be the direct job manager.
      */
-    public static final int SCOPE_FULL = 0x20;
+    SCOPE_FULL(true),
 
+    /**
+     * This scope starts all modes and also initializes the Job Manager
+     */
+    SCOPE_FULL_WITHJOBMANAGER(true);
+
+    public final boolean needsFullInit;
+
+    RoddyStartupModeScopes() {
+        this(false);
+    }
+
+    RoddyStartupModeScopes(boolean fullInit) {
+        this.needsFullInit = fullInit;
+    }
 }

--- a/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModes.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/RoddyStartupModes.groovy
@@ -52,23 +52,21 @@ enum RoddyStartupModes {
 
     autoselect(SCOPE_REDUCED, [useconfig]),
 
-    run(SCOPE_FULL, [test, useconfig, verbositylevel, debugOptions, waitforjobs, useiodir, disabletrackonlyuserjobs, trackonlystartedjobs, resubmitjobonerror, autosubmit, autocleanup, run, dontrun]),
+    run(SCOPE_FULL_WITHJOBMANAGER, [test, useconfig, verbositylevel, debugOptions, waitforjobs, useiodir, disabletrackonlyuserjobs, trackonlystartedjobs, resubmitjobonerror, autosubmit, autocleanup, run, dontrun]),
 
-    rerun(SCOPE_FULL, [test, run, dontrun, useconfig, verbositylevel, debugOptions, waitforjobs, useiodir, disabletrackonlyuserjobs, trackonlystartedjobs, resubmitjobonerror, autosubmit, autocleanup] as List<RoddyStartupOptions>),
+    rerun(SCOPE_FULL_WITHJOBMANAGER, [test, run, dontrun, useconfig, verbositylevel, debugOptions, waitforjobs, useiodir, disabletrackonlyuserjobs, trackonlystartedjobs, resubmitjobonerror, autosubmit, autocleanup] as List<RoddyStartupOptions>),
 
     testrun(SCOPE_FULL, [useconfig, verbositylevel, debugOptions, waitforjobs, useiodir, disabletrackonlyuserjobs, trackonlystartedjobs, resubmitjobonerror, autosubmit, autocleanup, run, dontrun] as List<RoddyStartupOptions>),
 
     testrerun(SCOPE_FULL, [useconfig, verbositylevel, debugOptions, waitforjobs, useiodir, disabletrackonlyuserjobs, trackonlystartedjobs, resubmitjobonerror, autosubmit, autocleanup, run, dontrun] as List<RoddyStartupOptions>),
 
-    rerunstep(SCOPE_FULL, [useconfig, verbositylevel, debugOptions, waitforjobs, useiodir, resubmitjobonerror] as List<RoddyStartupOptions>), // rerun a single step of an executed dataset.
+    rerunstep(SCOPE_FULL_WITHJOBMANAGER, [useconfig, verbositylevel, debugOptions, waitforjobs, useiodir, resubmitjobonerror] as List<RoddyStartupOptions>), // rerun a single step of an executed dataset.
 
-    checkworkflowstatus(SCOPE_FULL, [useconfig, verbositylevel, detailed] as List<RoddyStartupOptions>), // Show the (last) status of an executed dataset.
+    checkworkflowstatus(SCOPE_FULL_WITHJOBMANAGER, [useconfig, verbositylevel, detailed] as List<RoddyStartupOptions>), // Show the (last) status of an executed dataset.
 
-    cleanup(SCOPE_FULL, [useconfig, verbositylevel]),
+    cleanup(SCOPE_FULL_WITHJOBMANAGER, [useconfig, verbositylevel]),
 
-    abort(SCOPE_FULL, [useconfig, verbositylevel]),
-
-//    ui(SCOPE_FULL, [useconfig, verbositylevel]),
+    abort(SCOPE_FULL_WITHJOBMANAGER, [useconfig, verbositylevel]),
 
     rmi(SCOPE_FULL, [useconfig]),
 
@@ -84,14 +82,14 @@ enum RoddyStartupModes {
 
 //    setup(SCOPE_CLI)
 
-    public final int scope
+    public final RoddyStartupModeScopes scope
 
     /**
      * A list of valid startup options for this startup mode.
      */
     private List<RoddyStartupOptions> validOptions
 
-    RoddyStartupModes(int scope, List<RoddyStartupOptions> validOptions = []) {
+    RoddyStartupModes(RoddyStartupModeScopes scope, List<RoddyStartupOptions> validOptions = []) {
         this.validOptions = validOptions
         this.scope = scope
     }
@@ -194,7 +192,7 @@ enum RoddyStartupModes {
     }
 
     boolean needsFullInit() {
-        return scope == SCOPE_FULL
+        return scope.needsFullInit
     }
 
     @Override

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ProcessingToolReader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ProcessingToolReader.groovy
@@ -289,7 +289,7 @@ class ProcessingToolReader {
         if (fnPattern) {
             config.getFilenamePatterns().add(new OnScriptParameterFilenamePattern(_cls, toolID, pName, fnPattern))
         }
-e
+
         return tp
     }
 

--- a/RoddyCore/test/de/dkfz/roddy/RoddyTest.groovy
+++ b/RoddyCore/test/de/dkfz/roddy/RoddyTest.groovy
@@ -6,6 +6,7 @@
 
 package de.dkfz.roddy
 
+import de.dkfz.roddy.client.RoddyStartupModes
 import de.dkfz.roddy.config.ResourceSetSize
 import de.dkfz.roddy.execution.jobs.cluster.pbs.PBSJobManager
 import de.dkfz.roddy.client.cliclient.CommandLineCall
@@ -82,7 +83,7 @@ class RoddyTest {
     @Ignore
     @Test
     void testInitializeJobManager() {
-        Roddy.initializeJobManager(true)
+        Roddy.initializeJobManager(RoddyStartupModes.run)
         assert Roddy.getJobManager() instanceof PBSJobManager
     }
 


### PR DESCRIPTION
e.g. testrun/testrerun etc. do not need to init a cluster job manager.
In these cases, the direct sync job manager will be used.