### PR TITLE
Roddy autoselect was partially broken with a NullPointerException if …

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/Roddy.java
+++ b/RoddyCore/src/de/dkfz/roddy/Roddy.java
@@ -30,7 +30,6 @@ import de.dkfz.roddy.tools.RoddyConversionHelperMethods;
 import de.dkfz.roddy.tools.RoddyIOHelperMethods;
 import groovy.transform.CompileStatic;
 
-import javax.naming.ConfigurationException;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.lang.reflect.Constructor;

--- a/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/client/cliclient/RoddyCLIClient.groovy
@@ -27,6 +27,7 @@ import de.dkfz.roddy.execution.jobs.ProcessingParameters
 import de.dkfz.roddy.tools.LoggerWrapper
 import de.dkfz.roddy.tools.RoddyIOHelperMethods
 import de.dkfz.roddy.tools.ScannerWrapper
+import de.dkfz.roddy.tools.versions.Version
 
 import static de.dkfz.roddy.StringConstants.SPLIT_COMMA
 import static de.dkfz.roddy.client.RoddyStartupModes.*
@@ -488,13 +489,15 @@ public class RoddyCLIClient {
         return datasets;
     }
 
-    public static void autoselect(CommandLineCall clc) {
+    static void autoselect(CommandLineCall clc) {
 
-        String apiLevel = new ProjectLoader().getPluginRoddyAPILevel(clc.getAnalysisID());
-        if (apiLevel == null) //Explicitely query for null (then there is no auto detect!)
-            logger.postAlwaysInfo("Roddy API level could not be detected");
-        else
-            logger.postAlwaysInfo("Roddy API level for ${clc.getAnalysisID()} == ${apiLevel}");
+        String apiLevel = new ProjectLoader().getPluginRoddyAPILevel(clc.getAnalysisID())
+        if (apiLevel == null) {
+            def version = Version.fromString(Constants.APP_CURRENT_VERSION_STRING)
+            apiLevel = version.major + '.' + version.minor
+            logger.postAlwaysInfo("Using the current Roddy API level: ${apiLevel}")
+        } else
+            logger.postAlwaysInfo("Roddy API level for ${clc.getAnalysisID()}: ${apiLevel}")
     }
 
     public static void run(CommandLineCall clc) {

--- a/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/core/ProjectLoader.groovy
@@ -121,21 +121,23 @@ class ProjectLoader {
      * @return
      */
     String getPluginRoddyAPILevel(String configurationIdentifier) {
+        if (configurationIdentifier == null) return null
+
         extractProjectIDAndAnalysisIDOrFail(configurationIdentifier)
 
-        if (analysisID == null) return null; //Return null (which needs to be checked then) because an auto id is not possible.
+        if (analysisID == null) return null //Return null (which needs to be checked then) because an auto id is not possible.
 
         String fullAnalysisID = getFullAnalysisID(projectID, analysisID)
 
-        LibrariesFactory librariesFactory = LibrariesFactory.initializeFactory();
+        LibrariesFactory librariesFactory = LibrariesFactory.initializeFactory()
 
-        String pluginString; List<AnalysisImportKillSwitch> killSwitches;
+        String pluginString
         def res = dissectFullAnalysisID(fullAnalysisID)
-        pluginString = res[0];
+        pluginString = res[0]
 
-        PluginInfoMap mapOfPlugins = librariesFactory.loadMapOfAvailablePluginsForInstance();
-        PluginInfo pinfo = mapOfPlugins.getPluginInfoWithPluginString(pluginString);
-        return pinfo.getRoddyAPIVersion();
+        PluginInfoMap mapOfPlugins = librariesFactory.loadMapOfAvailablePluginsForInstance()
+        PluginInfo pinfo = mapOfPlugins.getPluginInfoWithPluginString(pluginString)
+        return pinfo.getRoddyAPIVersion()
     }
 
     /**
@@ -185,6 +187,7 @@ class ProjectLoader {
     }
 
     void extractProjectIDAndAnalysisIDOrFail(String configurationIdentifier) {
+        assert configurationIdentifier != null
         String[] splitProjectAnalysis
         if (configurationIdentifier.findAll("[@]").size() == 1) {
             splitProjectAnalysis = configurationIdentifier.split(StringConstants.SPLIT_AT)


### PR DESCRIPTION
…no plugin was requested but autoselect was used. This is a partial fix of the Roddy Java code and parts of the startup code.

After this roddy.sh help has to be called with --useRoddyVersion=current to get a help at all.

BTW: The startup scripts are such a mess. It already took me too much time to partially fix this and we should consider a complete rewrite (Groovy, Bash, compiled, or whatever).