### PR TITLE
Fix cfg could not be loaded message

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
@@ -348,9 +348,10 @@ class ConfigurationFactory {
             try {
                 Configuration cfg = getConfiguration(ic)
                 config.addParent(cfg)
-            } finally {
+            } catch(Exception ex) {
                 if (LibrariesFactory.getInstance().areLibrariesLoaded())
                     logger.severe("Configuration ${ic} cannot be loaded!")
+                throw ex
             }
         }
         return config


### PR DESCRIPTION
A small fix, which will prevent the configuration could not be loaded message. The message will still be displayed, if exceptions are thrown.