### PR TITLE
Change job config storage behaviour

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/execution/jobs/Job.groovy
@@ -523,7 +523,6 @@ class Job extends BEJob<BEJob, BEJobResult> {
 
         appendProcessingCommands(configuration)
 
-        storeJobConfigurationFile(createJobConfiguration())
 
         //See if the job should be executed
         if (contextLevel == ExecutionContextLevel.RUN || contextLevel == ExecutionContextLevel.CLEANUP) {
@@ -538,6 +537,7 @@ class Job extends BEJob<BEJob, BEJobResult> {
 
         //Execute the job or create a dummy command.
         if (runJob) {
+            storeJobConfigurationFile(createJobConfiguration())
             runResult = jobManager.submitJob(this)
             appendToJobStateLogfile(jobManager, executionContext, runResult, null)
             cmd = runResult.command

--- a/dist/plugins/TestPluginWithJarFile/TestPluginWithJarFile.iml
+++ b/dist/plugins/TestPluginWithJarFile/TestPluginWithJarFile.iml
@@ -11,10 +11,10 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="DefaultPlugin" />
     <orderEntry type="module" module-name="PluginBase" />
-    <orderEntry type="library" name="roddyBundledLibraries" level="project" />
-    <orderEntry type="module" module-name="RoddyToolLib" />
     <orderEntry type="module" module-name="Roddy" />
     <orderEntry type="library" name="R User Library" level="project" />
-    <orderEntry type="library" name="R Skeletons" level="application" />
+    <orderEntry type="library" name="groovy_2.4.9" level="application" />
+    <orderEntry type="module" module-name="Roddy_main" />
+    <orderEntry type="module" module-name="RoddyToolLib_main" />
   </component>
 </module>

--- a/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestCorrectExecution.xml
+++ b/dist/plugins/TestPluginWithJarFile/resources/configurationFiles/analysisTestCorrectExecution.xml
@@ -4,7 +4,7 @@
   ~ Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
   -->
 
-<configuration name='testAnalysisCorrectExecution' description='A test analysis for local and remote roddy workflow tests.'
+<configuration name='testCorrectExecutionAnalysis' description='A test analysis for local and remote roddy workflow tests.'
                configurationType='analysis' class='de.dkfz.roddy.core.Analysis' workflowClass='de.dkfz.roddy.knowledge.examples.SimpleWorkflowWithCorrectExecution'
                runtimeServiceClass="de.dkfz.roddy.knowledge.examples.SimpleRuntimeService"
                listOfUsedTools="testScript,testScriptExitBad,testFileWithChildren" usedToolFolders="devel"

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleFileStageSettings.java
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleFileStageSettings.java
@@ -7,7 +7,6 @@
 package de.dkfz.roddy.knowledge.examples;
 
 import de.dkfz.roddy.core.DataSet;
-import de.dkfz.roddy.core.InfoObject;
 import de.dkfz.roddy.knowledge.files.FileStage;
 import de.dkfz.roddy.knowledge.files.FileStageSettings;
 

--- a/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleRuntimeService.groovy
+++ b/dist/plugins/TestPluginWithJarFile/src/de/dkfz/roddy/knowledge/examples/SimpleRuntimeService.groovy
@@ -12,92 +12,92 @@ import de.dkfz.roddy.core.ExecutionContext
 import de.dkfz.roddy.core.RuntimeService
 import de.dkfz.roddy.execution.io.fs.FileSystemAccessProvider
 import de.dkfz.roddy.knowledge.files.BaseFile
-import de.dkfz.roddy.knowledge.files.BaseFile.ConstructionHelperForSourceFiles;
+import de.dkfz.roddy.knowledge.files.BaseFile.ConstructionHelperForSourceFiles
 
 /**
  */
 @groovy.transform.CompileStatic
-public class SimpleRuntimeService extends RuntimeService {
+class SimpleRuntimeService extends RuntimeService {
     @Override
-    public Map<String, Object> getDefaultJobParameters(ExecutionContext context, String toolID) {
-        Configuration cfg = context.getConfiguration();
-        String pid = context.getDataSet().toString();
-        Map<String, Object> parameters = new LinkedHashMap<>();
-        parameters.put("pid", (Object) pid);
-        parameters.put("PID", (Object) pid);
-        parameters.put("CONFIG_FILE", getNameOfConfigurationFile(context).getAbsolutePath());
-        parameters.put("ANALYSIS_DIR", context.getOutputDirectory().getParentFile().getParent());
+    Map<String, Object> getDefaultJobParameters(ExecutionContext context, String toolID) {
+        Configuration cfg = context.getConfiguration()
+        String pid = context.getDataSet().toString()
+        Map<String, Object> parameters = new LinkedHashMap<>()
+        parameters.put("pid", (Object) pid)
+        parameters.put("PID", (Object) pid)
+        parameters.put("CONFIG_FILE", getNameOfConfigurationFile(context).getAbsolutePath())
+        parameters.put("ANALYSIS_DIR", context.getOutputDirectory().getParentFile().getParent())
         if (toolID != null && toolID.length() > 0) {
-            parameters.put("PRM_TOOLS_DIR", cfg.getProcessingToolPath(context, toolID).getParent());
+            parameters.put("PRM_TOOLS_DIR", cfg.getProcessingToolPath(context, toolID).getParent())
         }
-        return parameters;
+        return parameters
     }
 
     @Override
-    public String createJobName(ExecutionContext executionContext, BaseFile file, String TOOLID, boolean reduceLevel) {
+    String createJobName(ExecutionContext executionContext, BaseFile file, String TOOLID, boolean reduceLevel) {
         return "RoddyTest_${TOOLID}"
     }
 
     @Override
-    public boolean isFileValid(BaseFile baseFile) {
+    boolean isFileValid(BaseFile baseFile) {
         //Parents valid?
-        boolean parentsValid = true;
+        boolean parentsValid = true
         for (BaseFile bf in baseFile.parentFiles) {
-            if (bf.isTemporaryFile()) continue; //We do not check the existence of parent files which are temporary.
-            if (bf.isSourceFile()) continue; //We do not check source files.
+            if (bf.isTemporaryFile()) continue //We do not check the existence of parent files which are temporary.
+            if (bf.isSourceFile()) continue //We do not check source files.
             if (!bf.isFileValid()) {
-                return false;
+                return false
             }
         }
 
-        boolean result = true;
+        boolean result = true
 
         //Source files should be marked as such and checked in a different way. They are assumed to be valid.
         if(baseFile.isSourceFile())
-            return true;
+            return true
 
         //Temporary files are also considered as valid.
         if(baseFile.isTemporaryFile())
-            return true;
+            return true
 
         try {
             //Was freshly created?
             if (baseFile.creatingJobsResult != null && baseFile.creatingJobsResult.wasExecuted) {
-                result = false;
+                result = false
             }
         } catch (Exception ex) {
-            result = false;
+            result = false
         }
 
         try {
             //Does it exist and is it readable?
             if (result && !baseFile.isFileReadable()) {
-                result = false;
+                result = false
             }
         } catch (Exception ex) {
-            result = false;
+            result = false
         }
 
         try {
             //Can it be validated?
             //TODO basefiles are always validated!
             if (result && !baseFile.checkFileValidity()) {
-                result = false;
+                result = false
             }
         } catch (Exception ex) {
-            result = false;
+            result = false
         }
 
 // If the file is not valid then also temporary parent files should be invalidated! Or at least checked.
         if (!result) { }
 
-        return result;
+        return result
     }
 
-    public SimpleTestTextFile createInitialTextFile(ExecutionContext ec) {
-        SimpleTestTextFile tf = new SimpleTestTextFile(new ConstructionHelperForSourceFiles(new File(getOutputFolderForDataSetAndAnalysis(ec.getDataSet(), ec.getAnalysis()).getAbsolutePath(), "textBase.txt"), ec, new SimpleFileStageSettings(ec.getDataSet(), "100", "R001"), null));
+    SimpleTestTextFile createInitialTextFile(ExecutionContext ec) {
+        SimpleTestTextFile tf = new SimpleTestTextFile(new ConstructionHelperForSourceFiles(new File(getOutputFolderForDataSetAndAnalysis(ec.getDataSet(), ec.getAnalysis()).getAbsolutePath(), "textBase.txt"), ec, new SimpleFileStageSettings(ec.getDataSet(), "100", "R001"), null))
         if (!FileSystemAccessProvider.getInstance().checkFile(tf.getPath()))
-            FileSystemAccessProvider.getInstance().createFileWithDefaultAccessRights(true, tf.getPath(), ec, true);
-        return tf;
+            FileSystemAccessProvider.getInstance().createFileWithDefaultAccessRights(true, tf.getPath(), ec, true)
+        return tf
     }
 }


### PR DESCRIPTION
Moved the line where the store job config is called to a location where
it is actually used. The job configuration is only necessary, when jobs
are run. In case of QUERY_STATUS, the line won't work an an error is
raised, that the file cannot be written. That is, because the exec
folder is not available at that point in time.

Also change one of the test workflows a bit so it will run again.