### PR TITLE
Modified gradle.build to clean all libraries (*.jar) from the dist/bi…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,9 +114,7 @@ dependencies {
     compile 'org.reflections:reflections:0.9.9-RC1'
 
     compile 'org.slf4j:slf4j-api:1.7.22'                        // MIT
-//    compile 'org.slf4j:slf4j-jcl:1.7.22'                        // MIT
     compile 'org.slf4j:slf4j-nop:1.7.22'                        // MIT
-//    compile 'org.slf4j:jcl-over-slf4j:1.7.22'                   // MIT
 
     compile 'com.hierynomus:sshj:0.23.0'                        // Apache 2.0
     compile 'net.vrallev.ecc:ecc-25519-java:1.0.1'              // Apache 2.0; elliptic curve cryptography (ECC) with Curve25519
@@ -132,7 +130,7 @@ dependencies {
 
     compile 'com.thoughtworks.xstream:xstream:1.4.5'            // BSD
 
-    // Testing libraries (do not end up in the fat-jar)
+    // Testing libraries
     testCompile 'junit:junit:4.12'                              // EPL 1.0
     testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'  // Apache 2.0
 }
@@ -155,8 +153,17 @@ sourceSets {
 
 mainClassName = "de.dkfz.roddy.Roddy"
 
+project.ext.librariesDirectory = new File(project.ext.currentDistributionDir, "lib")
+
+task cleanRuntimeLibs(type: Delete) {
+    delete fileTree(dir: librariesDirectory, exclude: ".keep")
+}
+
+clean.dependsOn(cleanRuntimeLibs)
+
+
 task copyRuntimeLibs(type: Copy) {
-    into new File(project.ext.currentDistributionDir, "lib")
+    into librariesDirectory
     from configurations.runtime
 }
 
@@ -172,7 +179,7 @@ jar {
         attributes("Implementation-Title": name)
         attributes 'Implementation-Version': getVersionName()
     }
-    dependsOn copyRuntimeLibs
+    dependsOn cleanRuntimeLibs, copyRuntimeLibs
 }
 
 /** Produce 2 distribution packages:

--- a/dist/bin/current/helperScripts/compileRoddyBinary.sh
+++ b/dist/bin/current/helperScripts/compileRoddyBinary.sh
@@ -11,7 +11,5 @@ echo JDKVersion=$JDK_VERSION > dist/bin/current/buildinfo.txt
 echo GroovyVersion=$GROOVY_VERSION >> dist/bin/current/buildinfo.txt
 echo RoddyAPIVersion=`head RoddyCore/buildversion.txt -n 1` >> dist/bin/current/buildinfo.txt
 
-(set +e rm  dist/bin/current/lib/*.jar 2> /dev/null)
-touch dist/bin/current/lib/.keep
 declare -a gradleParameters=$*
 ./gradlew build "${fullParameterList[@]:1:99}"


### PR DESCRIPTION
…n/current/libs before the `jar` target, i.e. before every library packing. Cleaning is also done for the `clean` target.