### PR TITLE
Gradle versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ deploy:
   api_key:
     secure: hUho+7TfYXa4AQXlR6RuaeB9NBDX9VG3CwPoxvxU4pzIKBq6nwKkcOIwYi3WihxRZ/79qcyLv519L2/Nz0aDO7ZNvU7auvdNz612AgcvlPbvm+q00fQXpgaNl9owHDmgukmfZhMg2P0gcSQIUa/rdlU6CTlfUFxgEcXXiYA5RfoxYLpL12rsGYbPw7CjCWHoo34Z0i24lE3KjwYYxwBVpB7ytlArY1xe9bRPLXSFrEcfx3D8+PfoktVxuJTC3zeXJj1TUEPoupA7KyC1MUFvXKAOprJH4b2XfYBJlF2loionyo3ynqCp5KQK2HQpirEI5aFUAFZ1FO7/7luHWdySP3pIYXV9I39kOGwTERAaETcHlQw0Rla7ZD19ailySPIL3ajTrSxzY6+CeROpt9efolbl22hyJTnVTUod7LEobYHoUZ4wjTD6wp11byqHzYjJekHajo6GCpZGWX6JFlLoNkixTtlmcrz6yGJhE02G1mtO/wM0nBDuAE8o1Mbp7Rj7qMW8QAMnAXzH5qRslrigOEDPPf8YUpyBLhFzVyH3owDQpk889+s76y1dzRA88v8xxdBYkh2byYoBEt8DLDuM/njPeoZjcsTGATDi2TmCk0mDYrJRR+w52Df8s4JLNuP1c1b9r0Yi7/10quGIVNBzc08b40NtF92yHHQB3zxxq4k=
   file:
-    - gradleBuild/distributions/RoddyEnv-*
-    - gradleBuild/distributions/Roddy-*
+    - gradleBuild/distributions/RoddyEnv-*.zip
+    - gradleBuild/distributions/Roddy-*.zip
   file_glob: true
   on:
     repo: eilslabs/Roddy

--- a/build.gradle
+++ b/build.gradle
@@ -31,15 +31,6 @@ plugins {
 group = "com.github.eilslabs"
 
 /**
- * Gets the version name from the current Git tag. If the current commit is not tagged,
- * this returned string will indicate that. Also if the repository is dirty.
- */
-String getVersionName() {
-    def dirtySuffix = grgit.status().isClean() ? '' : '-dirty'
-    return grgit.describe() + dirtySuffix
-}
-
-/**
  * -PignoreFailedTests                  Continue despite failed tests.
  * -PreleaseLevel={major,minor,patch}   When releasing, increase the major.minor.patch number. The build number is always increased.
  * -PallowDirtyRepo=true                Continue release despite dirty repo.
@@ -59,9 +50,6 @@ ext.langLevel = "1.8"
 sourceCompatibility = langLevel
 targetCompatibility = langLevel
 compileJava.options.fork = true
-
-// ext.buildVersion = getVersionName()
-ext.buildVersion = rootProject.version
 
 // Set -Pchecked on the command line to change this compiler parameter.
 if (!project.hasProperty("checked") || !project.checked) {
@@ -143,7 +131,7 @@ dependencies {
 }
 
 project.ext.currentDistributionDir = new File(rootProject.projectDir, "dist/bin/current")
-convention.add("releaseDir", new File(project.ext.currentDistributionDir, "../" + getVersionName()).absoluteFile)
+convention.add("releaseDir", new File(project.ext.currentDistributionDir, "../" + rootProject.version).absoluteFile)
 
 sourceSets {
     main {
@@ -178,28 +166,28 @@ jar {
     baseName = "Roddy"
     classifier = null
     version = null
-    // version = getVersionName()  // toggle to get a versioned jar name
+    // version = rootProject.version  // toggle to get a versioned jar name
     setDestinationDir(project.ext.currentDistributionDir)
     manifest {
         attributes("Implementation-Vendor": "German Cancer Research Center (DKFZ)")
         attributes 'Main-Class': mainClassName
         attributes("Implementation-Title": name)
-        attributes 'Implementation-Version': getVersionName()
+        attributes 'Implementation-Version': rootProject.version
     }
     dependsOn cleanRuntimeLibs, copyRuntimeLibs
 }
 
 /** Produce 2 distribution packages:
  *
- *  * Roddy.zip with everything that belongs into the dist/bin/current directory & some other smaller files.
- *  * RoddyEnv.zip with the runtime environment, starter script, etc.
+ *  * Roddy-*.zip with everything that belongs into the dist/bin/current directory & some other smaller files.
+ *  * RoddyEnv-*.zip with the runtime environment, starter script, etc.
  */
 distributions {
 
     roddy {
-        baseName = "Roddy-" + getVersionName()
+        baseName = "Roddy"
         contents {
-            into(getVersionName())
+            into(rootProject.version)
             from("dist/bin/current/") {
                 include("**")
             }
@@ -217,7 +205,7 @@ distributions {
     }
 
     roddyEnvironment {
-        baseName = "RoddyEnv-" + getVersionName()
+        baseName = "RoddyEnv"
         contents {
             from("./") {
                 include("roddy.sh")

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     }
     dependencies {
         classpath group: 'kr.motd.gradle', name: 'sphinx-gradle-plugin', version: '1.0.6'
+        classpath group: 'gradle.plugin.net.vivin', name: 'gradle-semantic-build-versioning', version: '4.0.0'
     }
 }
 
@@ -60,7 +61,8 @@ sourceCompatibility = langLevel
 targetCompatibility = langLevel
 compileJava.options.fork = true
 
-ext.buildVersion = getVersionName()
+// ext.buildVersion = getVersionName()
+ext.buildVersion = rootProject.version
 
 // Set -Pchecked on the command line to change this compiler parameter.
 if (!project.hasProperty("checked") || !project.checked) {
@@ -248,7 +250,7 @@ idea {
 
 // Gradle Wrapper
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.2.1'
+    gradleVersion = '3.3'
 }
 
 sphinx {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ buildscript {
     }
     dependencies {
         classpath group: 'kr.motd.gradle', name: 'sphinx-gradle-plugin', version: '1.0.6'
-        classpath group: 'gradle.plugin.net.vivin', name: 'gradle-semantic-build-versioning', version: '4.0.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -250,7 +250,7 @@ idea {
 
 // Gradle Wrapper
 task wrapper(type: Wrapper) {
-    gradleVersion = '3.3'
+    gradleVersion = '4.2.1'
 }
 
 sphinx {

--- a/semantic-build-versioning.gradle
+++ b/semantic-build-versioning.gradle
@@ -1,3 +1,5 @@
+tagPattern = ~/^\d+\.\d+\.\d+(?:-\S+)?$/
+
 preRelease {
     startingVersion = 'alpha.0'
     // The bumping scheme is alpha.0 -> alpha.1 -> ... -> alpha.n

--- a/semantic-build-versioning.gradle
+++ b/semantic-build-versioning.gradle
@@ -1,0 +1,16 @@
+preRelease {
+    startingVersion = 'alpha.0'
+    // The bumping scheme is alpha.0 -> alpha.1 -> ... -> alpha.n
+    bump = {
+        "alpha.${((it - ~/^alpha\./) as int) + 1}"
+    }
+}
+
+autobump {
+    newPreReleasePattern = ~/(?m)^\[new-pre-release\]\s*$/
+    promoteToReleasePattern = ~/(?m)^\[promote\]\s*$/
+    // Additionally allow [gitversion](https://gitversion.readthedocs.io/en/latest/more-info/version-increments/) patterns
+    majorPattern = ~/(?m)^(?:semver:\s+(?:major|breaking)|\[major\])\s*$/
+    minorPattern = ~/(?m)^(?:semver:\s+(?:minor|feature)|\[minor\])\s*$/
+    patchPattern = ~/(?m)^(?:semver:\s+(?:patch|fix)|\[patch\])\s*$/
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ buildscript {
         }
     }
     dependencies {
+        // The configuration of this plugin is in semantic-build-versioning.gradle.
         classpath group: 'gradle.plugin.net.vivin', name: 'gradle-semantic-build-versioning', version: '4.0.0'
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,14 @@
 rootProject.name = "Roddy"
+
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath group: 'gradle.plugin.net.vivin', name: 'gradle-semantic-build-versioning', version: '4.0.0'
+    }
+}
+
+apply plugin: 'net.vivin.gradle-semantic-build-versioning'    // MIT


### PR DESCRIPTION
Support for semantic versioning. Use [major], [minor], [patch] for increasing numbers (alternatively, as in gitversion, semver: major, semver: minor, semver: patch, etc.). Used plugin supports pre-release numbering.