### PR TITLE
Fix wrong value bundle id during conversion bug

### DIFF
--- a/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueBundle.java
+++ b/RoddyCore/src/de/dkfz/roddy/config/ConfigurationValueBundle.java
@@ -15,20 +15,19 @@ import java.util.Map;
  */
 public class ConfigurationValueBundle implements RecursiveOverridableMapContainer.Identifiable {
 
-    private static int cvbIDs = 0;
-
     private final Map<String, ConfigurationValue> values = new HashMap<>();
 
-    private final int id = cvbIDs++;
+    private final String id;
 
-    public ConfigurationValueBundle(Map<String, ConfigurationValue> values) {
+    public ConfigurationValueBundle(String id, Map<String, ConfigurationValue> values) {
+        this.id = id;
         if (values != null)
             this.values.putAll(values);
     }
 
     @Override
     public String getID() {
-        return "" + id;
+        return id;
     }
 
     public List<String> getKeys() {
@@ -38,10 +37,6 @@ public class ConfigurationValueBundle implements RecursiveOverridableMapContaine
     public List<ConfigurationValue> getValues() {
         return new LinkedList<>(values.values());
     }
-
-//    public ConfigurationValue get(String key) {
-//        return values.get(key);
-//    }
 
     public ConfigurationValue getAt(String key) {
         return values.get(key);

--- a/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/converters/BashConverter.groovy
@@ -414,7 +414,7 @@ class BashConverter extends ConfigurationConverter {
                         String key = cvarr[0]
                         bundleValues[key] = new ConfigurationValue(newCfg, key, cval[key.length() + 1..-1])
                     }
-                    cValueBundles[bundleName] = new ConfigurationValueBundle(bundleValues)
+                    cValueBundles[bundleName] = new ConfigurationValueBundle(bundleName, bundleValues)
                 } catch (Exception ex) {
                     logger.log(Level.SEVERE, ex.toString())
                 }

--- a/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
+++ b/RoddyCore/src/de/dkfz/roddy/config/loader/ConfigurationFactory.groovy
@@ -488,7 +488,8 @@ class ConfigurationFactory {
                 ConfigurationValue _cvalue = readConfigurationValue(cvalue, config)
                 bundleValues[_cvalue.id] = _cvalue
             }
-            cvBundles[cbundle.@name.text()] = new ConfigurationValueBundle(bundleValues)
+            def cBundleID = cbundle.@name.text()
+            cvBundles[cBundleID] = new ConfigurationValueBundle(cBundleID, bundleValues)
         }
     }
 


### PR DESCRIPTION
After some of the last changes, we corrected the behaviour of the
recursive value containers. The new code relied more on e.g. the method
getId() of contained values (of type Identifiable). However, when value
bundles were converted to Bash, the id was an integer starting from 0.

This was, because the value bundles did not store their string id but an
incrementing value! The behaviour has been fixed and the bundles are now
converted properly.